### PR TITLE
Fixed C# parser bug that occurs when the first parameter of an extension method is decorated with an attribute.

### DIFF
--- a/src/Libraries/NRefactory/Project/Src/Ast/Enums.cs
+++ b/src/Libraries/NRefactory/Project/Src/Ast/Enums.cs
@@ -113,7 +113,8 @@ namespace ICSharpCode.NRefactory.Ast
 		Out = 2,
 		Ref = 4,
 		Params = 8,
-		Optional = 16
+        Optional = 16,
+        This = 32
 	}
 	
 	public enum VarianceModifier

--- a/src/Libraries/NRefactory/Project/Src/Parser/CSharp/Parser.cs
+++ b/src/Libraries/NRefactory/Project/Src/Parser/CSharp/Parser.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text;
+using System.Linq;
 using ICSharpCode.NRefactory.Parser;
 using ICSharpCode.NRefactory.Ast;
 using ASTAttribute = ICSharpCode.NRefactory.Ast.Attribute;
@@ -26,7 +27,7 @@ partial class Parser : AbstractParser
 	const  bool   x            = false;
 	
 
-#line  18 "cs.ATG" 
+#line  19 "cs.ATG" 
 
 
 /*
@@ -35,7 +36,7 @@ partial class Parser : AbstractParser
 
 	void CS() {
 
-#line  180 "cs.ATG" 
+#line  181 "cs.ATG" 
 		lexer.NextToken(); // get the first token
 		compilationUnit = new CompilationUnit();
 		BlockStart(compilationUnit);
@@ -47,7 +48,7 @@ partial class Parser : AbstractParser
 			UsingDirective();
 		}
 		while (
-#line  187 "cs.ATG" 
+#line  188 "cs.ATG" 
 IsGlobalAttrTarget()) {
 			GlobalAttributeSection();
 		}
@@ -59,57 +60,57 @@ IsGlobalAttrTarget()) {
 
 	void ExternAliasDirective() {
 
-#line  360 "cs.ATG" 
+#line  361 "cs.ATG" 
 		ExternAliasDirective ead = new ExternAliasDirective { StartLocation = la.Location }; 
 		Expect(71);
 		Identifier();
 
-#line  363 "cs.ATG" 
+#line  364 "cs.ATG" 
 		if (t.val != "alias") Error("Expected 'extern alias'."); 
 		Identifier();
 
-#line  364 "cs.ATG" 
+#line  365 "cs.ATG" 
 		ead.Name = t.val; 
 		Expect(11);
 
-#line  365 "cs.ATG" 
+#line  366 "cs.ATG" 
 		ead.EndLocation = t.EndLocation; 
 
-#line  366 "cs.ATG" 
+#line  367 "cs.ATG" 
 		AddChild(ead); 
 	}
 
 	void UsingDirective() {
 
-#line  194 "cs.ATG" 
+#line  195 "cs.ATG" 
 		string qualident = null; TypeReference aliasedType = null;
 		string alias = null;
 		
 		Expect(121);
 
-#line  198 "cs.ATG" 
+#line  199 "cs.ATG" 
 		Location startPos = t.Location; 
 		if (
-#line  199 "cs.ATG" 
+#line  200 "cs.ATG" 
 IdentAndDoubleColon()) {
 			Identifier();
 
-#line  199 "cs.ATG" 
+#line  200 "cs.ATG" 
 			alias = t.val; 
 			Expect(10);
 		}
 		Qualident(
-#line  200 "cs.ATG" 
+#line  201 "cs.ATG" 
 out qualident);
 		if (la.kind == 3) {
 			lexer.NextToken();
 			NonArrayType(
-#line  201 "cs.ATG" 
+#line  202 "cs.ATG" 
 out aliasedType);
 		}
 		Expect(11);
 
-#line  203 "cs.ATG" 
+#line  204 "cs.ATG" 
 		if (qualident != null && qualident.Length > 0) {
 		 string name = (alias != null && alias != "global") ? alias + "." + qualident : qualident;
 		 INode node;
@@ -128,11 +129,11 @@ out aliasedType);
 	void GlobalAttributeSection() {
 		Expect(18);
 
-#line  220 "cs.ATG" 
+#line  221 "cs.ATG" 
 		Location startPos = t.Location; 
 		Identifier();
 
-#line  221 "cs.ATG" 
+#line  222 "cs.ATG" 
 		if (t.val != "assembly" && t.val != "module") Error("global attribute target specifier (assembly or module) expected");
 		string attributeTarget = t.val;
 		List<ASTAttribute> attributes = new List<ASTAttribute>();
@@ -140,20 +141,20 @@ out aliasedType);
 		
 		Expect(9);
 		Attribute(
-#line  226 "cs.ATG" 
+#line  227 "cs.ATG" 
 out attribute);
 
-#line  226 "cs.ATG" 
+#line  227 "cs.ATG" 
 		attributes.Add(attribute); 
 		while (
-#line  227 "cs.ATG" 
+#line  228 "cs.ATG" 
 NotFinalComma()) {
 			Expect(14);
 			Attribute(
-#line  227 "cs.ATG" 
+#line  228 "cs.ATG" 
 out attribute);
 
-#line  227 "cs.ATG" 
+#line  228 "cs.ATG" 
 			attributes.Add(attribute); 
 		}
 		if (la.kind == 14) {
@@ -161,7 +162,7 @@ out attribute);
 		}
 		Expect(19);
 
-#line  229 "cs.ATG" 
+#line  230 "cs.ATG" 
 		AttributeSection section = new AttributeSection {
 		   AttributeTarget = attributeTarget,
 		   Attributes = attributes,
@@ -174,7 +175,7 @@ out attribute);
 
 	void NamespaceMemberDecl() {
 
-#line  333 "cs.ATG" 
+#line  334 "cs.ATG" 
 		AttributeSection section;
 		List<AttributeSection> attributes = new List<AttributeSection>();
 		ModifierList m = new ModifierList();
@@ -183,13 +184,13 @@ out attribute);
 		if (la.kind == 88) {
 			lexer.NextToken();
 
-#line  339 "cs.ATG" 
+#line  340 "cs.ATG" 
 			Location startPos = t.Location; 
 			Qualident(
-#line  340 "cs.ATG" 
+#line  341 "cs.ATG" 
 out qualident);
 
-#line  340 "cs.ATG" 
+#line  341 "cs.ATG" 
 			INode node =  new NamespaceDeclaration(qualident);
 			node.StartLocation = startPos;
 			AddChild(node);
@@ -210,26 +211,26 @@ out qualident);
 				lexer.NextToken();
 			}
 
-#line  350 "cs.ATG" 
+#line  351 "cs.ATG" 
 			node.EndLocation   = t.EndLocation;
 			BlockEnd();
 			
 		} else if (StartOf(2)) {
 			while (la.kind == 18) {
 				AttributeSection(
-#line  354 "cs.ATG" 
+#line  355 "cs.ATG" 
 out section);
 
-#line  354 "cs.ATG" 
+#line  355 "cs.ATG" 
 				attributes.Add(section); 
 			}
 			while (StartOf(3)) {
 				TypeModifier(
-#line  355 "cs.ATG" 
+#line  356 "cs.ATG" 
 m);
 			}
 			TypeDecl(
-#line  356 "cs.ATG" 
+#line  357 "cs.ATG" 
 m, attributes);
 		} else SynErr(146);
 	}
@@ -321,33 +322,33 @@ m, attributes);
 	}
 
 	void Qualident(
-#line  490 "cs.ATG" 
+#line  491 "cs.ATG" 
 out string qualident) {
 		Identifier();
 
-#line  492 "cs.ATG" 
+#line  493 "cs.ATG" 
 		qualidentBuilder.Length = 0; qualidentBuilder.Append(t.val); 
 		while (
-#line  493 "cs.ATG" 
+#line  494 "cs.ATG" 
 DotAndIdent()) {
 			Expect(15);
 			Identifier();
 
-#line  493 "cs.ATG" 
+#line  494 "cs.ATG" 
 			qualidentBuilder.Append('.');
 			qualidentBuilder.Append(t.val); 
 			
 		}
 
-#line  496 "cs.ATG" 
+#line  497 "cs.ATG" 
 		qualident = qualidentBuilder.ToString(); 
 	}
 
 	void NonArrayType(
-#line  608 "cs.ATG" 
+#line  609 "cs.ATG" 
 out TypeReference type) {
 
-#line  610 "cs.ATG" 
+#line  611 "cs.ATG" 
 		Location startPos = la.Location;
 		string name;
 		int pointer = 0;
@@ -355,37 +356,37 @@ out TypeReference type) {
 		
 		if (StartOf(4)) {
 			ClassType(
-#line  616 "cs.ATG" 
+#line  617 "cs.ATG" 
 out type, false);
 		} else if (StartOf(5)) {
 			SimpleType(
-#line  617 "cs.ATG" 
+#line  618 "cs.ATG" 
 out name);
 
-#line  617 "cs.ATG" 
+#line  618 "cs.ATG" 
 			type = new TypeReference(name, true); 
 		} else if (la.kind == 123) {
 			lexer.NextToken();
 			Expect(6);
 
-#line  618 "cs.ATG" 
+#line  619 "cs.ATG" 
 			pointer = 1; type = new TypeReference("System.Void", true); 
 		} else SynErr(148);
 		if (la.kind == 12) {
 			NullableQuestionMark(
-#line  621 "cs.ATG" 
+#line  622 "cs.ATG" 
 ref type);
 		}
 		while (
-#line  623 "cs.ATG" 
+#line  624 "cs.ATG" 
 IsPointer()) {
 			Expect(6);
 
-#line  624 "cs.ATG" 
+#line  625 "cs.ATG" 
 			++pointer; 
 		}
 
-#line  626 "cs.ATG" 
+#line  627 "cs.ATG" 
 		if (type != null) {
 		type.PointerNestingLevel = pointer; 
 		type.EndLocation = t.EndLocation;
@@ -395,41 +396,41 @@ IsPointer()) {
 	}
 
 	void Attribute(
-#line  239 "cs.ATG" 
+#line  240 "cs.ATG" 
 out ASTAttribute attribute) {
 
-#line  240 "cs.ATG" 
+#line  241 "cs.ATG" 
 		string qualident;
 		string alias = null;
 		
 
-#line  244 "cs.ATG" 
+#line  245 "cs.ATG" 
 		Location startPos = la.Location; 
 		if (
-#line  245 "cs.ATG" 
+#line  246 "cs.ATG" 
 IdentAndDoubleColon()) {
 			Identifier();
 
-#line  246 "cs.ATG" 
+#line  247 "cs.ATG" 
 			alias = t.val; 
 			Expect(10);
 		}
 		Qualident(
-#line  249 "cs.ATG" 
+#line  250 "cs.ATG" 
 out qualident);
 
-#line  250 "cs.ATG" 
+#line  251 "cs.ATG" 
 		List<Expression> positional = new List<Expression>();
 		List<NamedArgumentExpression> named = new List<NamedArgumentExpression>();
 		string name = (alias != null && alias != "global") ? alias + "." + qualident : qualident;
 		
 		if (la.kind == 20) {
 			AttributeArguments(
-#line  254 "cs.ATG" 
+#line  255 "cs.ATG" 
 positional, named);
 		}
 
-#line  255 "cs.ATG" 
+#line  256 "cs.ATG" 
 		attribute = new ASTAttribute(name, positional, named); 
 		attribute.StartLocation = startPos;
 		attribute.EndLocation = t.EndLocation;
@@ -437,17 +438,17 @@ positional, named);
 	}
 
 	void AttributeArguments(
-#line  261 "cs.ATG" 
+#line  262 "cs.ATG" 
 List<Expression> positional, List<NamedArgumentExpression> named) {
 		Expect(20);
 		if (StartOf(6)) {
 			AttributeArgument(
-#line  265 "cs.ATG" 
+#line  266 "cs.ATG" 
 positional, named);
 			while (la.kind == 14) {
 				lexer.NextToken();
 				AttributeArgument(
-#line  268 "cs.ATG" 
+#line  269 "cs.ATG" 
 positional, named);
 			}
 		}
@@ -455,37 +456,37 @@ positional, named);
 	}
 
 	void AttributeArgument(
-#line  274 "cs.ATG" 
+#line  275 "cs.ATG" 
 List<Expression> positional, List<NamedArgumentExpression> named) {
 
-#line  275 "cs.ATG" 
+#line  276 "cs.ATG" 
 		string name = null; bool isNamed = false; Expression expr; Location startLocation = la.Location; 
 		if (
-#line  278 "cs.ATG" 
+#line  279 "cs.ATG" 
 IsAssignment()) {
 
-#line  278 "cs.ATG" 
+#line  279 "cs.ATG" 
 			isNamed = true; 
 			Identifier();
 
-#line  279 "cs.ATG" 
+#line  280 "cs.ATG" 
 			name = t.val; 
 			Expect(3);
 		} else if (
-#line  282 "cs.ATG" 
+#line  283 "cs.ATG" 
 IdentAndColon()) {
 			Identifier();
 
-#line  283 "cs.ATG" 
+#line  284 "cs.ATG" 
 			name = t.val; 
 			Expect(9);
 		} else if (StartOf(6)) {
 		} else SynErr(149);
 		Expr(
-#line  287 "cs.ATG" 
+#line  288 "cs.ATG" 
 out expr);
 
-#line  289 "cs.ATG" 
+#line  290 "cs.ATG" 
 		if (expr != null) {
 		if (isNamed) {
 			named.Add(new NamedArgumentExpression(name, expr) { StartLocation = startLocation, EndLocation = t.EndLocation });
@@ -501,68 +502,68 @@ out expr);
 	}
 
 	void Expr(
-#line  1805 "cs.ATG" 
+#line  1804 "cs.ATG" 
 out Expression expr) {
 
-#line  1806 "cs.ATG" 
+#line  1805 "cs.ATG" 
 		expr = null; Expression expr1 = null, expr2 = null; AssignmentOperatorType op; 
 
-#line  1808 "cs.ATG" 
+#line  1807 "cs.ATG" 
 		Location startLocation = la.Location; 
 		UnaryExpr(
-#line  1809 "cs.ATG" 
+#line  1808 "cs.ATG" 
 out expr);
 		if (StartOf(7)) {
 			AssignmentOperator(
-#line  1812 "cs.ATG" 
+#line  1811 "cs.ATG" 
 out op);
 			Expr(
-#line  1812 "cs.ATG" 
+#line  1811 "cs.ATG" 
 out expr1);
 
-#line  1812 "cs.ATG" 
+#line  1811 "cs.ATG" 
 			expr = new AssignmentExpression(expr, op, expr1); 
 		} else if (
-#line  1813 "cs.ATG" 
+#line  1812 "cs.ATG" 
 la.kind == Tokens.GreaterThan && Peek(1).kind == Tokens.GreaterEqual) {
 			AssignmentOperator(
-#line  1814 "cs.ATG" 
+#line  1813 "cs.ATG" 
 out op);
 			Expr(
-#line  1814 "cs.ATG" 
+#line  1813 "cs.ATG" 
 out expr1);
 
-#line  1814 "cs.ATG" 
+#line  1813 "cs.ATG" 
 			expr = new AssignmentExpression(expr, op, expr1); 
 		} else if (StartOf(8)) {
 			ConditionalOrExpr(
-#line  1816 "cs.ATG" 
+#line  1815 "cs.ATG" 
 ref expr);
 			if (la.kind == 13) {
 				lexer.NextToken();
 				Expr(
-#line  1817 "cs.ATG" 
+#line  1816 "cs.ATG" 
 out expr1);
 
-#line  1817 "cs.ATG" 
+#line  1816 "cs.ATG" 
 				expr = new BinaryOperatorExpression(expr, BinaryOperatorType.NullCoalescing, expr1); 
 			}
 			if (la.kind == 12) {
 				lexer.NextToken();
 				Expr(
-#line  1818 "cs.ATG" 
+#line  1817 "cs.ATG" 
 out expr1);
 				Expect(9);
 				Expr(
-#line  1818 "cs.ATG" 
+#line  1817 "cs.ATG" 
 out expr2);
 
-#line  1818 "cs.ATG" 
+#line  1817 "cs.ATG" 
 				expr = new ConditionalExpression(expr, expr1, expr2);  
 			}
 		} else SynErr(150);
 
-#line  1821 "cs.ATG" 
+#line  1820 "cs.ATG" 
 		if (expr != null) {
 		if (expr.StartLocation.IsEmpty)
 			expr.StartLocation = startLocation;
@@ -573,10 +574,10 @@ out expr2);
 	}
 
 	void AttributeSection(
-#line  303 "cs.ATG" 
+#line  304 "cs.ATG" 
 out AttributeSection section) {
 
-#line  305 "cs.ATG" 
+#line  306 "cs.ATG" 
 		string attributeTarget = "";
 		List<ASTAttribute> attributes = new List<ASTAttribute>();
 		ASTAttribute attribute;
@@ -584,44 +585,44 @@ out AttributeSection section) {
 		
 		Expect(18);
 
-#line  311 "cs.ATG" 
+#line  312 "cs.ATG" 
 		Location startPos = t.Location; 
 		if (
-#line  312 "cs.ATG" 
+#line  313 "cs.ATG" 
 IsLocalAttrTarget()) {
 			if (la.kind == 69) {
 				lexer.NextToken();
 
-#line  313 "cs.ATG" 
+#line  314 "cs.ATG" 
 				attributeTarget = "event";
 			} else if (la.kind == 101) {
 				lexer.NextToken();
 
-#line  314 "cs.ATG" 
+#line  315 "cs.ATG" 
 				attributeTarget = "return";
 			} else {
 				Identifier();
 
-#line  315 "cs.ATG" 
+#line  316 "cs.ATG" 
 				attributeTarget = t.val; 
 			}
 			Expect(9);
 		}
 		Attribute(
-#line  319 "cs.ATG" 
+#line  320 "cs.ATG" 
 out attribute);
 
-#line  319 "cs.ATG" 
+#line  320 "cs.ATG" 
 		attributes.Add(attribute); 
 		while (
-#line  320 "cs.ATG" 
+#line  321 "cs.ATG" 
 NotFinalComma()) {
 			Expect(14);
 			Attribute(
-#line  320 "cs.ATG" 
+#line  321 "cs.ATG" 
 out attribute);
 
-#line  320 "cs.ATG" 
+#line  321 "cs.ATG" 
 			attributes.Add(attribute); 
 		}
 		if (la.kind == 14) {
@@ -629,7 +630,7 @@ out attribute);
 		}
 		Expect(19);
 
-#line  322 "cs.ATG" 
+#line  323 "cs.ATG" 
 		section = new AttributeSection {
 		   AttributeTarget = attributeTarget,
 		   Attributes = attributes,
@@ -640,76 +641,76 @@ out attribute);
 	}
 
 	void TypeModifier(
-#line  693 "cs.ATG" 
+#line  695 "cs.ATG" 
 ModifierList m) {
 		switch (la.kind) {
 		case 89: {
 			lexer.NextToken();
 
-#line  695 "cs.ATG" 
+#line  697 "cs.ATG" 
 			m.Add(Modifiers.New, t.Location); 
 			break;
 		}
 		case 98: {
 			lexer.NextToken();
 
-#line  696 "cs.ATG" 
+#line  698 "cs.ATG" 
 			m.Add(Modifiers.Public, t.Location); 
 			break;
 		}
 		case 97: {
 			lexer.NextToken();
 
-#line  697 "cs.ATG" 
+#line  699 "cs.ATG" 
 			m.Add(Modifiers.Protected, t.Location); 
 			break;
 		}
 		case 84: {
 			lexer.NextToken();
 
-#line  698 "cs.ATG" 
+#line  700 "cs.ATG" 
 			m.Add(Modifiers.Internal, t.Location); 
 			break;
 		}
 		case 96: {
 			lexer.NextToken();
 
-#line  699 "cs.ATG" 
+#line  701 "cs.ATG" 
 			m.Add(Modifiers.Private, t.Location); 
 			break;
 		}
 		case 119: {
 			lexer.NextToken();
 
-#line  700 "cs.ATG" 
+#line  702 "cs.ATG" 
 			m.Add(Modifiers.Unsafe, t.Location); 
 			break;
 		}
 		case 49: {
 			lexer.NextToken();
 
-#line  701 "cs.ATG" 
+#line  703 "cs.ATG" 
 			m.Add(Modifiers.Abstract, t.Location); 
 			break;
 		}
 		case 103: {
 			lexer.NextToken();
 
-#line  702 "cs.ATG" 
+#line  704 "cs.ATG" 
 			m.Add(Modifiers.Sealed, t.Location); 
 			break;
 		}
 		case 107: {
 			lexer.NextToken();
 
-#line  703 "cs.ATG" 
+#line  705 "cs.ATG" 
 			m.Add(Modifiers.Static, t.Location); 
 			break;
 		}
 		case 126: {
 			lexer.NextToken();
 
-#line  704 "cs.ATG" 
+#line  706 "cs.ATG" 
 			m.Add(Modifiers.Partial, t.Location); 
 			break;
 		}
@@ -718,10 +719,10 @@ ModifierList m) {
 	}
 
 	void TypeDecl(
-#line  369 "cs.ATG" 
+#line  370 "cs.ATG" 
 ModifierList m, List<AttributeSection> attributes) {
 
-#line  371 "cs.ATG" 
+#line  372 "cs.ATG" 
 		TypeReference type;
 		List<TypeReference> names;
 		List<ParameterDeclarationExpression> p = new List<ParameterDeclarationExpression>();
@@ -730,11 +731,11 @@ ModifierList m, List<AttributeSection> attributes) {
 		
 		if (la.kind == 59) {
 
-#line  377 "cs.ATG" 
+#line  378 "cs.ATG" 
 			m.Check(Modifiers.Classes); 
 			lexer.NextToken();
 
-#line  378 "cs.ATG" 
+#line  379 "cs.ATG" 
 			TypeDeclaration newType = new TypeDeclaration(m.Modifier, attributes);
 			templates = newType.Templates;
 			AddChild(newType);
@@ -745,28 +746,28 @@ ModifierList m, List<AttributeSection> attributes) {
 			
 			Identifier();
 
-#line  386 "cs.ATG" 
+#line  387 "cs.ATG" 
 			newType.Name = t.val; 
 			if (la.kind == 23) {
 				TypeParameterList(
-#line  389 "cs.ATG" 
+#line  390 "cs.ATG" 
 templates);
 			}
 			if (la.kind == 9) {
 				ClassBase(
-#line  391 "cs.ATG" 
+#line  392 "cs.ATG" 
 out names);
 
-#line  391 "cs.ATG" 
+#line  392 "cs.ATG" 
 				newType.BaseTypes = names; 
 			}
 			while (la.kind == 127) {
 				TypeParameterConstraintsClause(
-#line  394 "cs.ATG" 
+#line  395 "cs.ATG" 
 templates);
 			}
 
-#line  396 "cs.ATG" 
+#line  397 "cs.ATG" 
 			newType.BodyStartLocation = t.EndLocation; 
 			Expect(16);
 			ClassBody();
@@ -775,18 +776,18 @@ templates);
 				lexer.NextToken();
 			}
 
-#line  400 "cs.ATG" 
+#line  401 "cs.ATG" 
 			newType.EndLocation = t.EndLocation; 
 			BlockEnd();
 			
 		} else if (StartOf(9)) {
 
-#line  403 "cs.ATG" 
+#line  404 "cs.ATG" 
 			m.Check(Modifiers.StructsInterfacesEnumsDelegates); 
 			if (la.kind == 109) {
 				lexer.NextToken();
 
-#line  404 "cs.ATG" 
+#line  405 "cs.ATG" 
 				TypeDeclaration newType = new TypeDeclaration(m.Modifier, attributes);
 				templates = newType.Templates;
 				newType.StartLocation = m.GetDeclarationLocation(t.Location);
@@ -796,42 +797,42 @@ templates);
 				
 				Identifier();
 
-#line  411 "cs.ATG" 
+#line  412 "cs.ATG" 
 				newType.Name = t.val; 
 				if (la.kind == 23) {
 					TypeParameterList(
-#line  414 "cs.ATG" 
+#line  415 "cs.ATG" 
 templates);
 				}
 				if (la.kind == 9) {
 					StructInterfaces(
-#line  416 "cs.ATG" 
+#line  417 "cs.ATG" 
 out names);
 
-#line  416 "cs.ATG" 
+#line  417 "cs.ATG" 
 					newType.BaseTypes = names; 
 				}
 				while (la.kind == 127) {
 					TypeParameterConstraintsClause(
-#line  419 "cs.ATG" 
+#line  420 "cs.ATG" 
 templates);
 				}
 
-#line  422 "cs.ATG" 
+#line  423 "cs.ATG" 
 				newType.BodyStartLocation = t.EndLocation; 
 				StructBody();
 				if (la.kind == 11) {
 					lexer.NextToken();
 				}
 
-#line  424 "cs.ATG" 
+#line  425 "cs.ATG" 
 				newType.EndLocation = t.EndLocation; 
 				BlockEnd();
 				
 			} else if (la.kind == 83) {
 				lexer.NextToken();
 
-#line  428 "cs.ATG" 
+#line  429 "cs.ATG" 
 				TypeDeclaration newType = new TypeDeclaration(m.Modifier, attributes);
 				templates = newType.Templates;
 				AddChild(newType);
@@ -841,42 +842,42 @@ templates);
 				
 				Identifier();
 
-#line  435 "cs.ATG" 
+#line  436 "cs.ATG" 
 				newType.Name = t.val; 
 				if (la.kind == 23) {
 					TypeParameterList(
-#line  438 "cs.ATG" 
+#line  439 "cs.ATG" 
 templates);
 				}
 				if (la.kind == 9) {
 					InterfaceBase(
-#line  440 "cs.ATG" 
+#line  441 "cs.ATG" 
 out names);
 
-#line  440 "cs.ATG" 
+#line  441 "cs.ATG" 
 					newType.BaseTypes = names; 
 				}
 				while (la.kind == 127) {
 					TypeParameterConstraintsClause(
-#line  443 "cs.ATG" 
+#line  444 "cs.ATG" 
 templates);
 				}
 
-#line  445 "cs.ATG" 
+#line  446 "cs.ATG" 
 				newType.BodyStartLocation = t.EndLocation; 
 				InterfaceBody();
 				if (la.kind == 11) {
 					lexer.NextToken();
 				}
 
-#line  447 "cs.ATG" 
+#line  448 "cs.ATG" 
 				newType.EndLocation = t.EndLocation; 
 				BlockEnd();
 				
 			} else if (la.kind == 68) {
 				lexer.NextToken();
 
-#line  451 "cs.ATG" 
+#line  452 "cs.ATG" 
 				TypeDeclaration newType = new TypeDeclaration(m.Modifier, attributes);
 				AddChild(newType);
 				BlockStart(newType);
@@ -885,79 +886,79 @@ templates);
 				
 				Identifier();
 
-#line  457 "cs.ATG" 
+#line  458 "cs.ATG" 
 				newType.Name = t.val; 
 				if (la.kind == 9) {
 					lexer.NextToken();
 					IntegralType(
-#line  458 "cs.ATG" 
+#line  459 "cs.ATG" 
 out name);
 
-#line  458 "cs.ATG" 
+#line  459 "cs.ATG" 
 					newType.BaseTypes.Add(new TypeReference(name, true)); 
 				}
 
-#line  460 "cs.ATG" 
+#line  461 "cs.ATG" 
 				newType.BodyStartLocation = t.EndLocation; 
 				EnumBody();
 				if (la.kind == 11) {
 					lexer.NextToken();
 				}
 
-#line  462 "cs.ATG" 
+#line  463 "cs.ATG" 
 				newType.EndLocation = t.EndLocation; 
 				BlockEnd();
 				
 			} else {
 				lexer.NextToken();
 
-#line  466 "cs.ATG" 
+#line  467 "cs.ATG" 
 				DelegateDeclaration delegateDeclr = new DelegateDeclaration(m.Modifier, attributes);
 				templates = delegateDeclr.Templates;
 				delegateDeclr.StartLocation = m.GetDeclarationLocation(t.Location);
 				
 				if (
-#line  470 "cs.ATG" 
+#line  471 "cs.ATG" 
 NotVoidPointer()) {
 					Expect(123);
 
-#line  470 "cs.ATG" 
+#line  471 "cs.ATG" 
 					delegateDeclr.ReturnType = new TypeReference("System.Void", true); 
 				} else if (StartOf(10)) {
 					Type(
-#line  471 "cs.ATG" 
+#line  472 "cs.ATG" 
 out type);
 
-#line  471 "cs.ATG" 
+#line  472 "cs.ATG" 
 					delegateDeclr.ReturnType = type; 
 				} else SynErr(152);
 				Identifier();
 
-#line  473 "cs.ATG" 
+#line  474 "cs.ATG" 
 				delegateDeclr.Name = t.val; 
 				if (la.kind == 23) {
 					TypeParameterList(
-#line  476 "cs.ATG" 
+#line  477 "cs.ATG" 
 templates);
 				}
 				Expect(20);
 				if (StartOf(11)) {
 					FormalParameterList(
-#line  478 "cs.ATG" 
+#line  479 "cs.ATG" 
 p);
 
-#line  478 "cs.ATG" 
+#line  479 "cs.ATG" 
 					delegateDeclr.Parameters = p; 
 				}
 				Expect(21);
 				while (la.kind == 127) {
 					TypeParameterConstraintsClause(
-#line  482 "cs.ATG" 
+#line  483 "cs.ATG" 
 templates);
 				}
 				Expect(11);
 
-#line  484 "cs.ATG" 
+#line  485 "cs.ATG" 
 				delegateDeclr.EndLocation = t.EndLocation;
 				AddChild(delegateDeclr);
 				
@@ -966,74 +967,74 @@ templates);
 	}
 
 	void TypeParameterList(
-#line  2377 "cs.ATG" 
+#line  2376 "cs.ATG" 
 List<TemplateDefinition> templates) {
 
-#line  2379 "cs.ATG" 
+#line  2378 "cs.ATG" 
 		TemplateDefinition template;
 		
 		Expect(23);
 		VariantTypeParameter(
-#line  2383 "cs.ATG" 
+#line  2382 "cs.ATG" 
 out template);
 
-#line  2383 "cs.ATG" 
+#line  2382 "cs.ATG" 
 		templates.Add(template); 
 		while (la.kind == 14) {
 			lexer.NextToken();
 			VariantTypeParameter(
-#line  2385 "cs.ATG" 
+#line  2384 "cs.ATG" 
 out template);
 
-#line  2385 "cs.ATG" 
+#line  2384 "cs.ATG" 
 			templates.Add(template); 
 		}
 		Expect(22);
 	}
 
 	void ClassBase(
-#line  499 "cs.ATG" 
+#line  500 "cs.ATG" 
 out List<TypeReference> names) {
 
-#line  501 "cs.ATG" 
+#line  502 "cs.ATG" 
 		TypeReference typeRef;
 		names = new List<TypeReference>();
 		
 		Expect(9);
 		ClassType(
-#line  505 "cs.ATG" 
+#line  506 "cs.ATG" 
 out typeRef, false);
 
-#line  505 "cs.ATG" 
+#line  506 "cs.ATG" 
 		if (typeRef != null) { names.Add(typeRef); } 
 		while (la.kind == 14) {
 			lexer.NextToken();
 			TypeName(
-#line  506 "cs.ATG" 
+#line  507 "cs.ATG" 
 out typeRef, false);
 
-#line  506 "cs.ATG" 
+#line  507 "cs.ATG" 
 			if (typeRef != null) { names.Add(typeRef); } 
 		}
 	}
 
 	void TypeParameterConstraintsClause(
-#line  2405 "cs.ATG" 
+#line  2404 "cs.ATG" 
 List<TemplateDefinition> templates) {
 
-#line  2406 "cs.ATG" 
+#line  2405 "cs.ATG" 
 		string name = ""; TypeReference type; 
 		Expect(127);
 		Identifier();
 
-#line  2409 "cs.ATG" 
+#line  2408 "cs.ATG" 
 		name = t.val; 
 		Expect(9);
 		TypeParameterConstraintsClauseBase(
-#line  2411 "cs.ATG" 
+#line  2410 "cs.ATG" 
 out type);
 
-#line  2412 "cs.ATG" 
+#line  2411 "cs.ATG" 
 		TemplateDefinition td = null;
 		foreach (TemplateDefinition d in templates) {
 			if (d.Name == name) {
@@ -1046,10 +1047,10 @@ out type);
 		while (la.kind == 14) {
 			lexer.NextToken();
 			TypeParameterConstraintsClauseBase(
-#line  2421 "cs.ATG" 
+#line  2420 "cs.ATG" 
 out type);
 
-#line  2422 "cs.ATG" 
+#line  2421 "cs.ATG" 
 			td = null;
 			foreach (TemplateDefinition d in templates) {
 				if (d.Name == name) {
@@ -1064,109 +1065,109 @@ out type);
 
 	void ClassBody() {
 
-#line  510 "cs.ATG" 
+#line  511 "cs.ATG" 
 		AttributeSection section; 
 		while (StartOf(12)) {
 
-#line  512 "cs.ATG" 
+#line  513 "cs.ATG" 
 			List<AttributeSection> attributes = new List<AttributeSection>();
 			ModifierList m = new ModifierList();
 			
 			while (!(StartOf(13))) {SynErr(154); lexer.NextToken(); }
 			while (la.kind == 18) {
 				AttributeSection(
-#line  516 "cs.ATG" 
+#line  517 "cs.ATG" 
 out section);
 
-#line  516 "cs.ATG" 
+#line  517 "cs.ATG" 
 				attributes.Add(section); 
 			}
 			MemberModifiers(
-#line  517 "cs.ATG" 
+#line  518 "cs.ATG" 
 m);
 			ClassMemberDecl(
-#line  518 "cs.ATG" 
+#line  519 "cs.ATG" 
 m, attributes);
 		}
 	}
 
 	void StructInterfaces(
-#line  522 "cs.ATG" 
+#line  523 "cs.ATG" 
 out List<TypeReference> names) {
 
-#line  524 "cs.ATG" 
+#line  525 "cs.ATG" 
 		TypeReference typeRef;
 		names = new List<TypeReference>();
 		
 		Expect(9);
 		TypeName(
-#line  528 "cs.ATG" 
+#line  529 "cs.ATG" 
 out typeRef, false);
 
-#line  528 "cs.ATG" 
+#line  529 "cs.ATG" 
 		if (typeRef != null) { names.Add(typeRef); } 
 		while (la.kind == 14) {
 			lexer.NextToken();
 			TypeName(
-#line  529 "cs.ATG" 
+#line  530 "cs.ATG" 
 out typeRef, false);
 
-#line  529 "cs.ATG" 
+#line  530 "cs.ATG" 
 			if (typeRef != null) { names.Add(typeRef); } 
 		}
 	}
 
 	void StructBody() {
 
-#line  533 "cs.ATG" 
+#line  534 "cs.ATG" 
 		AttributeSection section; 
 		Expect(16);
 		while (StartOf(14)) {
 
-#line  536 "cs.ATG" 
+#line  537 "cs.ATG" 
 			List<AttributeSection> attributes = new List<AttributeSection>();
 			ModifierList m = new ModifierList();
 			
 			while (la.kind == 18) {
 				AttributeSection(
-#line  539 "cs.ATG" 
+#line  540 "cs.ATG" 
 out section);
 
-#line  539 "cs.ATG" 
+#line  540 "cs.ATG" 
 				attributes.Add(section); 
 			}
 			MemberModifiers(
-#line  540 "cs.ATG" 
+#line  541 "cs.ATG" 
 m);
 			StructMemberDecl(
-#line  541 "cs.ATG" 
+#line  542 "cs.ATG" 
 m, attributes);
 		}
 		Expect(17);
 	}
 
 	void InterfaceBase(
-#line  546 "cs.ATG" 
+#line  547 "cs.ATG" 
 out List<TypeReference> names) {
 
-#line  548 "cs.ATG" 
+#line  549 "cs.ATG" 
 		TypeReference typeRef;
 		names = new List<TypeReference>();
 		
 		Expect(9);
 		TypeName(
-#line  552 "cs.ATG" 
+#line  553 "cs.ATG" 
 out typeRef, false);
 
-#line  552 "cs.ATG" 
+#line  553 "cs.ATG" 
 		if (typeRef != null) { names.Add(typeRef); } 
 		while (la.kind == 14) {
 			lexer.NextToken();
 			TypeName(
-#line  553 "cs.ATG" 
+#line  554 "cs.ATG" 
 out typeRef, false);
 
-#line  553 "cs.ATG" 
+#line  554 "cs.ATG" 
 			if (typeRef != null) { names.Add(typeRef); } 
 		}
 	}
@@ -1181,72 +1182,72 @@ out typeRef, false);
 	}
 
 	void IntegralType(
-#line  715 "cs.ATG" 
+#line  717 "cs.ATG" 
 out string name) {
 
-#line  715 "cs.ATG" 
+#line  717 "cs.ATG" 
 		name = ""; 
 		switch (la.kind) {
 		case 102: {
 			lexer.NextToken();
 
-#line  717 "cs.ATG" 
+#line  719 "cs.ATG" 
 			name = "System.SByte"; 
 			break;
 		}
 		case 54: {
 			lexer.NextToken();
 
-#line  718 "cs.ATG" 
+#line  720 "cs.ATG" 
 			name = "System.Byte"; 
 			break;
 		}
 		case 104: {
 			lexer.NextToken();
 
-#line  719 "cs.ATG" 
+#line  721 "cs.ATG" 
 			name = "System.Int16"; 
 			break;
 		}
 		case 120: {
 			lexer.NextToken();
 
-#line  720 "cs.ATG" 
+#line  722 "cs.ATG" 
 			name = "System.UInt16"; 
 			break;
 		}
 		case 82: {
 			lexer.NextToken();
 
-#line  721 "cs.ATG" 
+#line  723 "cs.ATG" 
 			name = "System.Int32"; 
 			break;
 		}
 		case 116: {
 			lexer.NextToken();
 
-#line  722 "cs.ATG" 
+#line  724 "cs.ATG" 
 			name = "System.UInt32"; 
 			break;
 		}
 		case 87: {
 			lexer.NextToken();
 
-#line  723 "cs.ATG" 
+#line  725 "cs.ATG" 
 			name = "System.Int64"; 
 			break;
 		}
 		case 117: {
 			lexer.NextToken();
 
-#line  724 "cs.ATG" 
+#line  726 "cs.ATG" 
 			name = "System.UInt64"; 
 			break;
 		}
 		case 57: {
 			lexer.NextToken();
 
-#line  725 "cs.ATG" 
+#line  727 "cs.ATG" 
 			name = "System.Char"; 
 			break;
 		}
@@ -1256,25 +1257,25 @@ out string name) {
 
 	void EnumBody() {
 
-#line  562 "cs.ATG" 
+#line  563 "cs.ATG" 
 		FieldDeclaration f; 
 		Expect(16);
 		if (StartOf(17)) {
 			EnumMemberDecl(
-#line  565 "cs.ATG" 
+#line  566 "cs.ATG" 
 out f);
 
-#line  565 "cs.ATG" 
+#line  566 "cs.ATG" 
 			AddChild(f); 
 			while (
-#line  566 "cs.ATG" 
+#line  567 "cs.ATG" 
 NotFinalComma()) {
 				Expect(14);
 				EnumMemberDecl(
-#line  567 "cs.ATG" 
+#line  568 "cs.ATG" 
 out f);
 
-#line  567 "cs.ATG" 
+#line  568 "cs.ATG" 
 				AddChild(f); 
 			}
 			if (la.kind == 14) {
@@ -1285,115 +1286,115 @@ out f);
 	}
 
 	void Type(
-#line  573 "cs.ATG" 
+#line  574 "cs.ATG" 
 out TypeReference type) {
 		TypeWithRestriction(
-#line  575 "cs.ATG" 
+#line  576 "cs.ATG" 
 out type, true, false);
 	}
 
 	void FormalParameterList(
-#line  645 "cs.ATG" 
+#line  646 "cs.ATG" 
 List<ParameterDeclarationExpression> parameter) {
 
-#line  648 "cs.ATG" 
+#line  649 "cs.ATG" 
 		ParameterDeclarationExpression p;
 		AttributeSection section;
 		List<AttributeSection> attributes = new List<AttributeSection>();
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  653 "cs.ATG" 
+#line  654 "cs.ATG" 
 out section);
 
-#line  653 "cs.ATG" 
+#line  654 "cs.ATG" 
 			attributes.Add(section); 
 		}
 		FixedParameter(
-#line  654 "cs.ATG" 
+#line  655 "cs.ATG" 
 out p);
 
-#line  654 "cs.ATG" 
+#line  655 "cs.ATG" 
 		p.Attributes = attributes;
 		parameter.Add(p);
 		
 		while (la.kind == 14) {
 			lexer.NextToken();
 
-#line  658 "cs.ATG" 
+#line  659 "cs.ATG" 
 			attributes = new List<AttributeSection>(); 
 			while (la.kind == 18) {
 				AttributeSection(
-#line  659 "cs.ATG" 
+#line  660 "cs.ATG" 
 out section);
 
-#line  659 "cs.ATG" 
+#line  660 "cs.ATG" 
 				attributes.Add(section); 
 			}
 			FixedParameter(
-#line  660 "cs.ATG" 
+#line  661 "cs.ATG" 
 out p);
 
-#line  660 "cs.ATG" 
+#line  661 "cs.ATG" 
 			p.Attributes = attributes; parameter.Add(p); 
 		}
 	}
 
 	void ClassType(
-#line  707 "cs.ATG" 
+#line  709 "cs.ATG" 
 out TypeReference typeRef, bool canBeUnbound) {
 
-#line  708 "cs.ATG" 
+#line  710 "cs.ATG" 
 		TypeReference r; typeRef = null; 
 		if (StartOf(18)) {
 			TypeName(
-#line  710 "cs.ATG" 
+#line  712 "cs.ATG" 
 out r, canBeUnbound);
 
-#line  710 "cs.ATG" 
+#line  712 "cs.ATG" 
 			typeRef = r; 
 		} else if (la.kind == 91) {
 			lexer.NextToken();
 
-#line  711 "cs.ATG" 
+#line  713 "cs.ATG" 
 			typeRef = new TypeReference("System.Object", true); typeRef.StartLocation = t.Location; typeRef.EndLocation = t.EndLocation; 
 		} else if (la.kind == 108) {
 			lexer.NextToken();
 
-#line  712 "cs.ATG" 
+#line  714 "cs.ATG" 
 			typeRef = new TypeReference("System.String", true); typeRef.StartLocation = t.Location; typeRef.EndLocation = t.EndLocation; 
 		} else SynErr(157);
 	}
 
 	void TypeName(
-#line  2318 "cs.ATG" 
+#line  2317 "cs.ATG" 
 out TypeReference typeRef, bool canBeUnbound) {
 
-#line  2319 "cs.ATG" 
+#line  2318 "cs.ATG" 
 		List<TypeReference> typeArguments = null;
 		string alias = null;
 		string qualident;
 		Location startLocation = la.Location;
 		
 		if (
-#line  2325 "cs.ATG" 
+#line  2324 "cs.ATG" 
 IdentAndDoubleColon()) {
 			Identifier();
 
-#line  2326 "cs.ATG" 
+#line  2325 "cs.ATG" 
 			alias = t.val; 
 			Expect(10);
 		}
 		Qualident(
-#line  2329 "cs.ATG" 
+#line  2328 "cs.ATG" 
 out qualident);
 		if (la.kind == 23) {
 			TypeArgumentList(
-#line  2330 "cs.ATG" 
+#line  2329 "cs.ATG" 
 out typeArguments, canBeUnbound);
 		}
 
-#line  2332 "cs.ATG" 
+#line  2331 "cs.ATG" 
 		if (alias == null) {
 		typeRef = new TypeReference(qualident, typeArguments);
 		} else if (alias == "global") {
@@ -1404,143 +1405,143 @@ out typeArguments, canBeUnbound);
 		}
 		
 		while (
-#line  2341 "cs.ATG" 
+#line  2340 "cs.ATG" 
 DotAndIdent()) {
 			Expect(15);
 
-#line  2342 "cs.ATG" 
+#line  2341 "cs.ATG" 
 			typeArguments = null; 
 			Qualident(
-#line  2343 "cs.ATG" 
+#line  2342 "cs.ATG" 
 out qualident);
 			if (la.kind == 23) {
 				TypeArgumentList(
-#line  2344 "cs.ATG" 
+#line  2343 "cs.ATG" 
 out typeArguments, canBeUnbound);
 			}
 
-#line  2345 "cs.ATG" 
+#line  2344 "cs.ATG" 
 			typeRef = new InnerClassTypeReference(typeRef, qualident, typeArguments); 
 		}
 
-#line  2347 "cs.ATG" 
+#line  2346 "cs.ATG" 
 		typeRef.StartLocation = startLocation; typeRef.EndLocation = t.EndLocation; 
 	}
 
 	void MemberModifiers(
-#line  728 "cs.ATG" 
+#line  730 "cs.ATG" 
 ModifierList m) {
 		while (StartOf(19)) {
 			switch (la.kind) {
 			case 49: {
 				lexer.NextToken();
 
-#line  731 "cs.ATG" 
+#line  733 "cs.ATG" 
 				m.Add(Modifiers.Abstract, t.Location); 
 				break;
 			}
 			case 71: {
 				lexer.NextToken();
 
-#line  732 "cs.ATG" 
+#line  734 "cs.ATG" 
 				m.Add(Modifiers.Extern, t.Location); 
 				break;
 			}
 			case 84: {
 				lexer.NextToken();
 
-#line  733 "cs.ATG" 
+#line  735 "cs.ATG" 
 				m.Add(Modifiers.Internal, t.Location); 
 				break;
 			}
 			case 89: {
 				lexer.NextToken();
 
-#line  734 "cs.ATG" 
+#line  736 "cs.ATG" 
 				m.Add(Modifiers.New, t.Location); 
 				break;
 			}
 			case 94: {
 				lexer.NextToken();
 
-#line  735 "cs.ATG" 
+#line  737 "cs.ATG" 
 				m.Add(Modifiers.Override, t.Location); 
 				break;
 			}
 			case 96: {
 				lexer.NextToken();
 
-#line  736 "cs.ATG" 
+#line  738 "cs.ATG" 
 				m.Add(Modifiers.Private, t.Location); 
 				break;
 			}
 			case 97: {
 				lexer.NextToken();
 
-#line  737 "cs.ATG" 
+#line  739 "cs.ATG" 
 				m.Add(Modifiers.Protected, t.Location); 
 				break;
 			}
 			case 98: {
 				lexer.NextToken();
 
-#line  738 "cs.ATG" 
+#line  740 "cs.ATG" 
 				m.Add(Modifiers.Public, t.Location); 
 				break;
 			}
 			case 99: {
 				lexer.NextToken();
 
-#line  739 "cs.ATG" 
+#line  741 "cs.ATG" 
 				m.Add(Modifiers.ReadOnly, t.Location); 
 				break;
 			}
 			case 103: {
 				lexer.NextToken();
 
-#line  740 "cs.ATG" 
+#line  742 "cs.ATG" 
 				m.Add(Modifiers.Sealed, t.Location); 
 				break;
 			}
 			case 107: {
 				lexer.NextToken();
 
-#line  741 "cs.ATG" 
+#line  743 "cs.ATG" 
 				m.Add(Modifiers.Static, t.Location); 
 				break;
 			}
 			case 74: {
 				lexer.NextToken();
 
-#line  742 "cs.ATG" 
+#line  744 "cs.ATG" 
 				m.Add(Modifiers.Fixed, t.Location); 
 				break;
 			}
 			case 119: {
 				lexer.NextToken();
 
-#line  743 "cs.ATG" 
+#line  745 "cs.ATG" 
 				m.Add(Modifiers.Unsafe, t.Location); 
 				break;
 			}
 			case 122: {
 				lexer.NextToken();
 
-#line  744 "cs.ATG" 
+#line  746 "cs.ATG" 
 				m.Add(Modifiers.Virtual, t.Location); 
 				break;
 			}
 			case 124: {
 				lexer.NextToken();
 
-#line  745 "cs.ATG" 
+#line  747 "cs.ATG" 
 				m.Add(Modifiers.Volatile, t.Location); 
 				break;
 			}
 			case 126: {
 				lexer.NextToken();
 
-#line  746 "cs.ATG" 
+#line  748 "cs.ATG" 
 				m.Add(Modifiers.Partial, t.Location); 
 				break;
 			}
@@ -1549,23 +1550,23 @@ ModifierList m) {
 	}
 
 	void ClassMemberDecl(
-#line  1081 "cs.ATG" 
+#line  1080 "cs.ATG" 
 ModifierList m, List<AttributeSection> attributes) {
 
-#line  1082 "cs.ATG" 
+#line  1081 "cs.ATG" 
 		BlockStatement stmt = null; 
 		if (StartOf(20)) {
 			StructMemberDecl(
-#line  1084 "cs.ATG" 
+#line  1083 "cs.ATG" 
 m, attributes);
 		} else if (la.kind == 27) {
 
-#line  1085 "cs.ATG" 
+#line  1084 "cs.ATG" 
 			m.Check(Modifiers.Destructors); Location startPos = la.Location; 
 			lexer.NextToken();
 			Identifier();
 
-#line  1086 "cs.ATG" 
+#line  1085 "cs.ATG" 
 			DestructorDeclaration d = new DestructorDeclaration(t.val, m.Modifier, attributes); 
 			d.Modifier = m.Modifier;
 			d.StartLocation = m.GetDeclarationLocation(startPos);
@@ -1573,17 +1574,17 @@ m, attributes);
 			Expect(20);
 			Expect(21);
 
-#line  1090 "cs.ATG" 
+#line  1089 "cs.ATG" 
 			d.EndLocation = t.EndLocation; 
 			if (la.kind == 16) {
 				Block(
-#line  1090 "cs.ATG" 
+#line  1089 "cs.ATG" 
 out stmt);
 			} else if (la.kind == 11) {
 				lexer.NextToken();
 			} else SynErr(158);
 
-#line  1091 "cs.ATG" 
+#line  1090 "cs.ATG" 
 			d.Body = stmt;
 			AddChild(d);
 			
@@ -1591,10 +1592,10 @@ out stmt);
 	}
 
 	void StructMemberDecl(
-#line  750 "cs.ATG" 
+#line  752 "cs.ATG" 
 ModifierList m, List<AttributeSection> attributes) {
 
-#line  752 "cs.ATG" 
+#line  754 "cs.ATG" 
 		string qualident = null;
 		TypeReference type;
 		Expression expr;
@@ -1602,22 +1603,21 @@ ModifierList m, List<AttributeSection> attributes) {
 		BlockStatement stmt = null;
 		List<TemplateDefinition> templates = new List<TemplateDefinition>();
 		TypeReference explicitInterface = null;
-		bool isExtensionMethod = false;
 		
 		if (la.kind == 60) {
 
-#line  762 "cs.ATG" 
+#line  763 "cs.ATG" 
 			m.Check(Modifiers.Constants); 
 			lexer.NextToken();
 
-#line  763 "cs.ATG" 
+#line  764 "cs.ATG" 
 			Location startPos = t.Location; 
 			Type(
-#line  764 "cs.ATG" 
+#line  765 "cs.ATG" 
 out type);
 			Identifier();
 
-#line  764 "cs.ATG" 
+#line  765 "cs.ATG" 
 			FieldDeclaration fd = new FieldDeclaration(attributes, type, m.Modifier | Modifiers.Const);
 			fd.StartLocation = m.GetDeclarationLocation(startPos);
 			VariableDeclaration f = new VariableDeclaration(t.val);
@@ -1627,16 +1627,16 @@ out type);
 			
 			Expect(3);
 			Expr(
-#line  771 "cs.ATG" 
+#line  772 "cs.ATG" 
 out expr);
 
-#line  771 "cs.ATG" 
+#line  772 "cs.ATG" 
 			f.Initializer = expr; 
 			while (la.kind == 14) {
 				lexer.NextToken();
 				Identifier();
 
-#line  772 "cs.ATG" 
+#line  773 "cs.ATG" 
 				f = new VariableDeclaration(t.val);
 				f.StartLocation = t.Location;
 				f.TypeReference = type;
@@ -1644,55 +1644,49 @@ out expr);
 				
 				Expect(3);
 				Expr(
-#line  777 "cs.ATG" 
+#line  778 "cs.ATG" 
 out expr);
 
-#line  777 "cs.ATG" 
+#line  778 "cs.ATG" 
 				f.EndLocation = t.EndLocation; f.Initializer = expr; 
 			}
 			Expect(11);
 
-#line  778 "cs.ATG" 
+#line  779 "cs.ATG" 
 			fd.EndLocation = t.EndLocation; AddChild(fd); 
 		} else if (
-#line  782 "cs.ATG" 
+#line  783 "cs.ATG" 
 NotVoidPointer()) {
 
-#line  782 "cs.ATG" 
+#line  783 "cs.ATG" 
 			m.Check(Modifiers.PropertysEventsMethods); 
 			Expect(123);
 
-#line  783 "cs.ATG" 
+#line  784 "cs.ATG" 
 			Location startPos = t.Location; 
 			if (
-#line  784 "cs.ATG" 
+#line  785 "cs.ATG" 
 IsExplicitInterfaceImplementation()) {
 				TypeName(
-#line  785 "cs.ATG" 
+#line  786 "cs.ATG" 
 out explicitInterface, false);
 
-#line  786 "cs.ATG" 
+#line  787 "cs.ATG" 
 				if (la.kind != Tokens.Dot || Peek(1).kind != Tokens.This) {
 				qualident = TypeReference.StripLastIdentifierFromType(ref explicitInterface);
 				 } 
 			} else if (StartOf(18)) {
 				Identifier();
 
-#line  789 "cs.ATG" 
+#line  790 "cs.ATG" 
 				qualident = t.val; 
 			} else SynErr(160);
 			if (la.kind == 23) {
 				TypeParameterList(
-#line  792 "cs.ATG" 
+#line  793 "cs.ATG" 
 templates);
 			}
 			Expect(20);
-			if (la.kind == 111) {
-				lexer.NextToken();
-
-#line  795 "cs.ATG" 
-				isExtensionMethod = true; /* C# 3.0 */ 
-			}
 			if (StartOf(11)) {
 				FormalParameterList(
 #line  796 "cs.ATG" 
@@ -1710,7 +1704,7 @@ p);
 			StartLocation = m.GetDeclarationLocation(startPos),
 			EndLocation = t.EndLocation,
 			Templates = templates,
-			IsExtensionMethod = isExtensionMethod
+			IsExtensionMethod = p.Any(param => param.ParamModifier == ParameterModifiers.This)
 			};
 			if (explicitInterface != null)
 				SafeAdd(methodDeclaration, methodDeclaration.InterfaceImplementations, new InterfaceImplementation(explicitInterface, qualident));
@@ -2157,20 +2151,14 @@ out explicitInterface, false);
 templates);
 						}
 						Expect(20);
-						if (la.kind == 111) {
-							lexer.NextToken();
-
-#line  1017 "cs.ATG" 
-							isExtensionMethod = true; 
-						}
 						if (StartOf(11)) {
 							FormalParameterList(
-#line  1018 "cs.ATG" 
+#line  1017 "cs.ATG" 
 p);
 						}
 						Expect(21);
 
-#line  1020 "cs.ATG" 
+#line  1019 "cs.ATG" 
 						MethodDeclaration methodDeclaration = new MethodDeclaration {
 						Name = qualident,
 						Modifier = m.Modifier,
@@ -2182,29 +2170,29 @@ p);
 							methodDeclaration.InterfaceImplementations.Add(new InterfaceImplementation(explicitInterface, qualident));
 						methodDeclaration.StartLocation = m.GetDeclarationLocation(startPos);
 						methodDeclaration.EndLocation   = t.EndLocation;
-						methodDeclaration.IsExtensionMethod = isExtensionMethod;
+						methodDeclaration.IsExtensionMethod = p.Any(param => param.ParamModifier == ParameterModifiers.This);
 						methodDeclaration.Templates = templates;
 						AddChild(methodDeclaration);
 						                                      
 						while (la.kind == 127) {
 							TypeParameterConstraintsClause(
-#line  1035 "cs.ATG" 
+#line  1034 "cs.ATG" 
 templates);
 						}
 						if (la.kind == 16) {
 							Block(
-#line  1036 "cs.ATG" 
+#line  1035 "cs.ATG" 
 out stmt);
 						} else if (la.kind == 11) {
 							lexer.NextToken();
 						} else SynErr(169);
 
-#line  1036 "cs.ATG" 
+#line  1035 "cs.ATG" 
 						methodDeclaration.Body  = (BlockStatement)stmt; 
 					} else {
 						lexer.NextToken();
 
-#line  1039 "cs.ATG" 
+#line  1038 "cs.ATG" 
 						PropertyDeclaration pDecl = new PropertyDeclaration(qualident, type, m.Modifier, attributes); 
 						if (explicitInterface != null)
 						pDecl.InterfaceImplementations.Add(new InterfaceImplementation(explicitInterface, qualident));
@@ -2215,11 +2203,11 @@ out stmt);
 						      PropertySetRegion setRegion;
 						   
 						AccessorDecls(
-#line  1048 "cs.ATG" 
+#line  1047 "cs.ATG" 
 out getRegion, out setRegion);
 						Expect(17);
 
-#line  1050 "cs.ATG" 
+#line  1049 "cs.ATG" 
 						pDecl.GetRegion = getRegion;
 						pDecl.SetRegion = setRegion;
 						pDecl.BodyEnd = t.EndLocation;
@@ -2228,17 +2216,17 @@ out getRegion, out setRegion);
 					}
 				} else if (la.kind == 15) {
 
-#line  1058 "cs.ATG" 
+#line  1057 "cs.ATG" 
 					m.Check(Modifiers.Indexers); 
 					lexer.NextToken();
 					Expect(111);
 					Expect(18);
 					FormalParameterList(
-#line  1059 "cs.ATG" 
+#line  1058 "cs.ATG" 
 p);
 					Expect(19);
 
-#line  1060 "cs.ATG" 
+#line  1059 "cs.ATG" 
 					PropertyDeclaration indexer = new PropertyDeclaration(m.Modifier | Modifiers.Default, attributes, "Item", p);
 					indexer.StartLocation = m.GetDeclarationLocation(startPos);
 					indexer.EndLocation   = t.EndLocation;
@@ -2250,14 +2238,14 @@ p);
 					    
 					Expect(16);
 
-#line  1069 "cs.ATG" 
+#line  1068 "cs.ATG" 
 					Location bodyStart = t.Location; 
 					AccessorDecls(
-#line  1070 "cs.ATG" 
+#line  1069 "cs.ATG" 
 out getRegion, out setRegion);
 					Expect(17);
 
-#line  1071 "cs.ATG" 
+#line  1070 "cs.ATG" 
 					indexer.BodyStart = bodyStart;
 					indexer.BodyEnd   = t.EndLocation;
 					indexer.GetRegion = getRegion;
@@ -2271,7 +2259,7 @@ out getRegion, out setRegion);
 
 	void InterfaceMemberDecl() {
 
-#line  1098 "cs.ATG" 
+#line  1097 "cs.ATG" 
 		TypeReference type;
 		
 		AttributeSection section;
@@ -2286,49 +2274,49 @@ out getRegion, out setRegion);
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  1111 "cs.ATG" 
+#line  1110 "cs.ATG" 
 out section);
 
-#line  1111 "cs.ATG" 
+#line  1110 "cs.ATG" 
 			attributes.Add(section); 
 		}
 		if (la.kind == 89) {
 			lexer.NextToken();
 
-#line  1112 "cs.ATG" 
+#line  1111 "cs.ATG" 
 			mod = Modifiers.New; startLocation = t.Location; 
 		}
 		if (
-#line  1115 "cs.ATG" 
+#line  1114 "cs.ATG" 
 NotVoidPointer()) {
 			Expect(123);
 
-#line  1115 "cs.ATG" 
+#line  1114 "cs.ATG" 
 			if (startLocation.IsEmpty) startLocation = t.Location; 
 			Identifier();
 
-#line  1116 "cs.ATG" 
+#line  1115 "cs.ATG" 
 			name = t.val; 
 			if (la.kind == 23) {
 				TypeParameterList(
-#line  1117 "cs.ATG" 
+#line  1116 "cs.ATG" 
 templates);
 			}
 			Expect(20);
 			if (StartOf(11)) {
 				FormalParameterList(
-#line  1118 "cs.ATG" 
+#line  1117 "cs.ATG" 
 parameters);
 			}
 			Expect(21);
 			while (la.kind == 127) {
 				TypeParameterConstraintsClause(
-#line  1119 "cs.ATG" 
+#line  1118 "cs.ATG" 
 templates);
 			}
 			Expect(11);
 
-#line  1121 "cs.ATG" 
+#line  1120 "cs.ATG" 
 			MethodDeclaration md = new MethodDeclaration {
 			Name = name, Modifier = mod, TypeReference = new TypeReference("System.Void", true), 
 			Parameters = parameters, Attributes = attributes, Templates = templates,
@@ -2339,37 +2327,37 @@ templates);
 		} else if (StartOf(22)) {
 			if (StartOf(10)) {
 				Type(
-#line  1129 "cs.ATG" 
+#line  1128 "cs.ATG" 
 out type);
 
-#line  1129 "cs.ATG" 
+#line  1128 "cs.ATG" 
 				if (startLocation.IsEmpty) startLocation = t.Location; 
 				if (StartOf(18)) {
 					Identifier();
 
-#line  1131 "cs.ATG" 
+#line  1130 "cs.ATG" 
 					name = t.val; Location qualIdentEndLocation = t.EndLocation; 
 					if (la.kind == 20 || la.kind == 23) {
 						if (la.kind == 23) {
 							TypeParameterList(
-#line  1135 "cs.ATG" 
+#line  1134 "cs.ATG" 
 templates);
 						}
 						Expect(20);
 						if (StartOf(11)) {
 							FormalParameterList(
-#line  1136 "cs.ATG" 
+#line  1135 "cs.ATG" 
 parameters);
 						}
 						Expect(21);
 						while (la.kind == 127) {
 							TypeParameterConstraintsClause(
-#line  1138 "cs.ATG" 
+#line  1137 "cs.ATG" 
 templates);
 						}
 						Expect(11);
 
-#line  1139 "cs.ATG" 
+#line  1138 "cs.ATG" 
 						MethodDeclaration md = new MethodDeclaration {
 						Name = name, Modifier = mod, TypeReference = type,
 						Parameters = parameters, Attributes = attributes, Templates = templates,
@@ -2379,59 +2367,59 @@ templates);
 						
 					} else if (la.kind == 16) {
 
-#line  1148 "cs.ATG" 
+#line  1147 "cs.ATG" 
 						PropertyDeclaration pd = new PropertyDeclaration(name, type, mod, attributes);
 						AddChild(pd); 
 						lexer.NextToken();
 
-#line  1151 "cs.ATG" 
+#line  1150 "cs.ATG" 
 						Location bodyStart = t.Location;
 						InterfaceAccessors(
-#line  1152 "cs.ATG" 
+#line  1151 "cs.ATG" 
 out getBlock, out setBlock);
 						Expect(17);
 
-#line  1153 "cs.ATG" 
+#line  1152 "cs.ATG" 
 						pd.GetRegion = getBlock; pd.SetRegion = setBlock; pd.StartLocation = startLocation; pd.EndLocation = qualIdentEndLocation; pd.BodyStart = bodyStart; pd.BodyEnd = t.EndLocation; 
 					} else SynErr(173);
 				} else if (la.kind == 111) {
 					lexer.NextToken();
 					Expect(18);
 					FormalParameterList(
-#line  1156 "cs.ATG" 
+#line  1155 "cs.ATG" 
 parameters);
 					Expect(19);
 
-#line  1157 "cs.ATG" 
+#line  1156 "cs.ATG" 
 					Location bracketEndLocation = t.EndLocation; 
 
-#line  1158 "cs.ATG" 
+#line  1157 "cs.ATG" 
 					PropertyDeclaration id = new PropertyDeclaration(mod | Modifiers.Default, attributes, "Item", parameters);
 					id.TypeReference = type;
 					  AddChild(id); 
 					Expect(16);
 
-#line  1161 "cs.ATG" 
+#line  1160 "cs.ATG" 
 					Location bodyStart = t.Location;
 					InterfaceAccessors(
-#line  1162 "cs.ATG" 
+#line  1161 "cs.ATG" 
 out getBlock, out setBlock);
 					Expect(17);
 
-#line  1164 "cs.ATG" 
+#line  1163 "cs.ATG" 
 					id.GetRegion = getBlock; id.SetRegion = setBlock; id.StartLocation = startLocation;  id.EndLocation = bracketEndLocation; id.BodyStart = bodyStart; id.BodyEnd = t.EndLocation;
 				} else SynErr(174);
 			} else {
 				lexer.NextToken();
 
-#line  1167 "cs.ATG" 
+#line  1166 "cs.ATG" 
 				if (startLocation.IsEmpty) startLocation = t.Location; 
 				Type(
-#line  1168 "cs.ATG" 
+#line  1167 "cs.ATG" 
 out type);
 				Identifier();
 
-#line  1169 "cs.ATG" 
+#line  1168 "cs.ATG" 
 				EventDeclaration ed = new EventDeclaration {
 				TypeReference = type, Name = t.val, Modifier = mod, Attributes = attributes
 				};
@@ -2439,17 +2427,17 @@ out type);
 				
 				Expect(11);
 
-#line  1175 "cs.ATG" 
+#line  1174 "cs.ATG" 
 				ed.StartLocation = startLocation; ed.EndLocation = t.EndLocation; 
 			}
 		} else SynErr(175);
 	}
 
 	void EnumMemberDecl(
-#line  1180 "cs.ATG" 
+#line  1179 "cs.ATG" 
 out FieldDeclaration f) {
 
-#line  1182 "cs.ATG" 
+#line  1181 "cs.ATG" 
 		Expression expr = null;
 		List<AttributeSection> attributes = new List<AttributeSection>();
 		AttributeSection section = null;
@@ -2457,15 +2445,15 @@ out FieldDeclaration f) {
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  1188 "cs.ATG" 
+#line  1187 "cs.ATG" 
 out section);
 
-#line  1188 "cs.ATG" 
+#line  1187 "cs.ATG" 
 			attributes.Add(section); 
 		}
 		Identifier();
 
-#line  1189 "cs.ATG" 
+#line  1188 "cs.ATG" 
 		f = new FieldDeclaration(attributes);
 		varDecl         = new VariableDeclaration(t.val);
 		f.Fields.Add(varDecl);
@@ -2475,19 +2463,19 @@ out section);
 		if (la.kind == 3) {
 			lexer.NextToken();
 			Expr(
-#line  1195 "cs.ATG" 
+#line  1194 "cs.ATG" 
 out expr);
 
-#line  1195 "cs.ATG" 
+#line  1194 "cs.ATG" 
 			varDecl.Initializer = expr; 
 		}
 	}
 
 	void TypeWithRestriction(
-#line  578 "cs.ATG" 
+#line  579 "cs.ATG" 
 out TypeReference type, bool allowNullable, bool canBeUnbound) {
 
-#line  580 "cs.ATG" 
+#line  581 "cs.ATG" 
 		Location startPos = la.Location;
 		string name;
 		int pointer = 0;
@@ -2495,59 +2483,59 @@ out TypeReference type, bool allowNullable, bool canBeUnbound) {
 		
 		if (StartOf(4)) {
 			ClassType(
-#line  586 "cs.ATG" 
+#line  587 "cs.ATG" 
 out type, canBeUnbound);
 		} else if (StartOf(5)) {
 			SimpleType(
-#line  587 "cs.ATG" 
+#line  588 "cs.ATG" 
 out name);
 
-#line  587 "cs.ATG" 
+#line  588 "cs.ATG" 
 			type = new TypeReference(name, true); type.StartLocation = startPos; type.EndLocation = t.EndLocation; 
 		} else if (la.kind == 123) {
 			lexer.NextToken();
 			Expect(6);
 
-#line  588 "cs.ATG" 
+#line  589 "cs.ATG" 
 			pointer = 1; type = new TypeReference("System.Void", true); type.StartLocation = startPos; type.EndLocation = t.EndLocation; 
 		} else SynErr(176);
 
-#line  589 "cs.ATG" 
+#line  590 "cs.ATG" 
 		List<int> r = new List<int>(); 
 		if (
-#line  591 "cs.ATG" 
+#line  592 "cs.ATG" 
 allowNullable && la.kind == Tokens.Question) {
 			NullableQuestionMark(
-#line  591 "cs.ATG" 
+#line  592 "cs.ATG" 
 ref type);
 		}
 		while (
-#line  593 "cs.ATG" 
+#line  594 "cs.ATG" 
 IsPointerOrDims()) {
 
-#line  593 "cs.ATG" 
+#line  594 "cs.ATG" 
 			int i = 0; 
 			if (la.kind == 6) {
 				lexer.NextToken();
 
-#line  594 "cs.ATG" 
+#line  595 "cs.ATG" 
 				++pointer; 
 			} else if (la.kind == 18) {
 				lexer.NextToken();
 				while (la.kind == 14) {
 					lexer.NextToken();
 
-#line  595 "cs.ATG" 
+#line  596 "cs.ATG" 
 					++i; 
 				}
 				Expect(19);
 
-#line  595 "cs.ATG" 
+#line  596 "cs.ATG" 
 				r.Add(i); 
 			} else SynErr(177);
 		}
 
-#line  598 "cs.ATG" 
+#line  599 "cs.ATG" 
 		if (type != null) {
 		type.RankSpecifier = r.ToArray();
 		type.PointerNestingLevel = pointer;
@@ -2558,155 +2546,160 @@ IsPointerOrDims()) {
 	}
 
 	void SimpleType(
-#line  634 "cs.ATG" 
+#line  635 "cs.ATG" 
 out string name) {
 
-#line  635 "cs.ATG" 
+#line  636 "cs.ATG" 
 		name = String.Empty; 
 		if (StartOf(23)) {
 			IntegralType(
-#line  637 "cs.ATG" 
+#line  638 "cs.ATG" 
 out name);
 		} else if (la.kind == 75) {
 			lexer.NextToken();
 
-#line  638 "cs.ATG" 
+#line  639 "cs.ATG" 
 			name = "System.Single"; 
 		} else if (la.kind == 66) {
 			lexer.NextToken();
 
-#line  639 "cs.ATG" 
+#line  640 "cs.ATG" 
 			name = "System.Double"; 
 		} else if (la.kind == 62) {
 			lexer.NextToken();
 
-#line  640 "cs.ATG" 
+#line  641 "cs.ATG" 
 			name = "System.Decimal"; 
 		} else if (la.kind == 52) {
 			lexer.NextToken();
 
-#line  641 "cs.ATG" 
+#line  642 "cs.ATG" 
 			name = "System.Boolean"; 
 		} else SynErr(178);
 	}
 
 	void NullableQuestionMark(
-#line  2351 "cs.ATG" 
+#line  2350 "cs.ATG" 
 ref TypeReference typeRef) {
 
-#line  2352 "cs.ATG" 
+#line  2351 "cs.ATG" 
 		List<TypeReference> typeArguments = new List<TypeReference>(1); 
 		Expect(12);
 
-#line  2356 "cs.ATG" 
+#line  2355 "cs.ATG" 
 		if (typeRef != null) typeArguments.Add(typeRef);
 		typeRef = new TypeReference("System.Nullable", typeArguments) { IsKeyword = true };
 		
 	}
 
 	void FixedParameter(
-#line  664 "cs.ATG" 
+#line  665 "cs.ATG" 
 out ParameterDeclarationExpression p) {
 
-#line  666 "cs.ATG" 
+#line  667 "cs.ATG" 
 		TypeReference type;
 		ParameterModifiers mod = ParameterModifiers.In;
 		Location start = la.Location;
 		Expression expr;
 		
-		if (la.kind == 93 || la.kind == 95 || la.kind == 100) {
+		if (StartOf(24)) {
 			if (la.kind == 100) {
 				lexer.NextToken();
 
-#line  673 "cs.ATG" 
+#line  674 "cs.ATG" 
 				mod = ParameterModifiers.Ref; 
 			} else if (la.kind == 93) {
 				lexer.NextToken();
 
-#line  674 "cs.ATG" 
+#line  675 "cs.ATG" 
 				mod = ParameterModifiers.Out; 
+			} else if (la.kind == 95) {
+				lexer.NextToken();
+
+#line  676 "cs.ATG" 
+				mod = ParameterModifiers.Params; 
 			} else {
 				lexer.NextToken();
 
-#line  675 "cs.ATG" 
-				mod = ParameterModifiers.Params; 
+#line  677 "cs.ATG" 
+				mod = ParameterModifiers.This; 
 			}
 		}
 		Type(
-#line  677 "cs.ATG" 
+#line  679 "cs.ATG" 
 out type);
 		Identifier();
 
-#line  678 "cs.ATG" 
+#line  680 "cs.ATG" 
 		p = new ParameterDeclarationExpression(type, t.val, mod); 
 		if (la.kind == 3) {
 			lexer.NextToken();
 			Expr(
-#line  679 "cs.ATG" 
+#line  681 "cs.ATG" 
 out expr);
 
-#line  679 "cs.ATG" 
+#line  681 "cs.ATG" 
 			p.DefaultValue = expr; p.ParamModifier |= ParameterModifiers.Optional; 
 		}
 
-#line  680 "cs.ATG" 
+#line  682 "cs.ATG" 
 		p.StartLocation = start; p.EndLocation = t.EndLocation; 
 	}
 
 	void AccessorModifiers(
-#line  683 "cs.ATG" 
+#line  685 "cs.ATG" 
 out ModifierList m) {
 
-#line  684 "cs.ATG" 
+#line  686 "cs.ATG" 
 		m = new ModifierList(); 
 		if (la.kind == 96) {
 			lexer.NextToken();
 
-#line  686 "cs.ATG" 
+#line  688 "cs.ATG" 
 			m.Add(Modifiers.Private, t.Location); 
 		} else if (la.kind == 97) {
 			lexer.NextToken();
 
-#line  687 "cs.ATG" 
+#line  689 "cs.ATG" 
 			m.Add(Modifiers.Protected, t.Location); 
 			if (la.kind == 84) {
 				lexer.NextToken();
 
-#line  688 "cs.ATG" 
+#line  690 "cs.ATG" 
 				m.Add(Modifiers.Internal, t.Location); 
 			}
 		} else if (la.kind == 84) {
 			lexer.NextToken();
 
-#line  689 "cs.ATG" 
+#line  691 "cs.ATG" 
 			m.Add(Modifiers.Internal, t.Location); 
 			if (la.kind == 97) {
 				lexer.NextToken();
 
-#line  690 "cs.ATG" 
+#line  692 "cs.ATG" 
 				m.Add(Modifiers.Protected, t.Location); 
 			}
 		} else SynErr(179);
 	}
 
 	void Block(
-#line  1315 "cs.ATG" 
+#line  1314 "cs.ATG" 
 out BlockStatement stmt) {
 		Expect(16);
 
-#line  1317 "cs.ATG" 
+#line  1316 "cs.ATG" 
 		BlockStatement blockStmt = new BlockStatement();
 		blockStmt.StartLocation = t.Location;
 		BlockStart(blockStmt);
 		if (!ParseMethodBodies) lexer.SkipCurrentBlock(0);
 		
-		while (StartOf(24)) {
+		while (StartOf(25)) {
 			Statement();
 		}
 		while (!(la.kind == 0 || la.kind == 17)) {SynErr(180); lexer.NextToken(); }
 		Expect(17);
 
-#line  1325 "cs.ATG" 
+#line  1324 "cs.ATG" 
 		stmt = blockStmt;
 		blockStmt.EndLocation = t.EndLocation;
 		BlockEnd();
@@ -2714,10 +2707,10 @@ out BlockStatement stmt) {
 	}
 
 	void EventAccessorDecls(
-#line  1252 "cs.ATG" 
+#line  1251 "cs.ATG" 
 out EventAddRegion addBlock, out EventRemoveRegion removeBlock) {
 
-#line  1253 "cs.ATG" 
+#line  1252 "cs.ATG" 
 		AttributeSection section;
 		List<AttributeSection> attributes = new List<AttributeSection>();
 		BlockStatement stmt;
@@ -2726,93 +2719,93 @@ out EventAddRegion addBlock, out EventRemoveRegion removeBlock) {
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  1260 "cs.ATG" 
+#line  1259 "cs.ATG" 
 out section);
 
-#line  1260 "cs.ATG" 
+#line  1259 "cs.ATG" 
 			attributes.Add(section); 
 		}
 		if (la.kind == 130) {
 
-#line  1262 "cs.ATG" 
+#line  1261 "cs.ATG" 
 			addBlock = new EventAddRegion(attributes); 
 			AddAccessorDecl(
-#line  1263 "cs.ATG" 
+#line  1262 "cs.ATG" 
 out stmt);
 
-#line  1263 "cs.ATG" 
+#line  1262 "cs.ATG" 
 			attributes = new List<AttributeSection>(); addBlock.Block = stmt; 
 			while (la.kind == 18) {
 				AttributeSection(
-#line  1264 "cs.ATG" 
+#line  1263 "cs.ATG" 
 out section);
 
-#line  1264 "cs.ATG" 
+#line  1263 "cs.ATG" 
 				attributes.Add(section); 
 			}
 			RemoveAccessorDecl(
-#line  1265 "cs.ATG" 
+#line  1264 "cs.ATG" 
 out stmt);
 
-#line  1265 "cs.ATG" 
+#line  1264 "cs.ATG" 
 			removeBlock = new EventRemoveRegion(attributes); removeBlock.Block = stmt; 
 		} else if (la.kind == 131) {
 			RemoveAccessorDecl(
-#line  1267 "cs.ATG" 
+#line  1266 "cs.ATG" 
 out stmt);
 
-#line  1267 "cs.ATG" 
+#line  1266 "cs.ATG" 
 			removeBlock = new EventRemoveRegion(attributes); removeBlock.Block = stmt; attributes = new List<AttributeSection>(); 
 			while (la.kind == 18) {
 				AttributeSection(
-#line  1268 "cs.ATG" 
+#line  1267 "cs.ATG" 
 out section);
 
-#line  1268 "cs.ATG" 
+#line  1267 "cs.ATG" 
 				attributes.Add(section); 
 			}
 			AddAccessorDecl(
-#line  1269 "cs.ATG" 
+#line  1268 "cs.ATG" 
 out stmt);
 
-#line  1269 "cs.ATG" 
+#line  1268 "cs.ATG" 
 			addBlock = new EventAddRegion(attributes); addBlock.Block = stmt; 
 		} else SynErr(181);
 	}
 
 	void ConstructorInitializer(
-#line  1345 "cs.ATG" 
+#line  1344 "cs.ATG" 
 out ConstructorInitializer ci) {
 
-#line  1346 "cs.ATG" 
+#line  1345 "cs.ATG" 
 		Expression expr; ci = new ConstructorInitializer(); 
 		Expect(9);
 		if (la.kind == 51) {
 			lexer.NextToken();
 
-#line  1350 "cs.ATG" 
+#line  1349 "cs.ATG" 
 			ci.ConstructorInitializerType = ConstructorInitializerType.Base; 
 		} else if (la.kind == 111) {
 			lexer.NextToken();
 
-#line  1351 "cs.ATG" 
+#line  1350 "cs.ATG" 
 			ci.ConstructorInitializerType = ConstructorInitializerType.This; 
 		} else SynErr(182);
 		Expect(20);
-		if (StartOf(25)) {
+		if (StartOf(26)) {
 			Argument(
-#line  1354 "cs.ATG" 
+#line  1353 "cs.ATG" 
 out expr);
 
-#line  1354 "cs.ATG" 
+#line  1353 "cs.ATG" 
 			SafeAdd(ci, ci.Arguments, expr); 
 			while (la.kind == 14) {
 				lexer.NextToken();
 				Argument(
-#line  1355 "cs.ATG" 
+#line  1354 "cs.ATG" 
 out expr);
 
-#line  1355 "cs.ATG" 
+#line  1354 "cs.ATG" 
 				SafeAdd(ci, ci.Arguments, expr); 
 			}
 		}
@@ -2820,161 +2813,161 @@ out expr);
 	}
 
 	void OverloadableOperator(
-#line  1368 "cs.ATG" 
+#line  1367 "cs.ATG" 
 out OverloadableOperatorType op) {
 
-#line  1369 "cs.ATG" 
+#line  1368 "cs.ATG" 
 		op = OverloadableOperatorType.None; 
 		switch (la.kind) {
 		case 4: {
 			lexer.NextToken();
 
-#line  1371 "cs.ATG" 
+#line  1370 "cs.ATG" 
 			op = OverloadableOperatorType.Add; 
 			break;
 		}
 		case 5: {
 			lexer.NextToken();
 
-#line  1372 "cs.ATG" 
+#line  1371 "cs.ATG" 
 			op = OverloadableOperatorType.Subtract; 
 			break;
 		}
 		case 24: {
 			lexer.NextToken();
 
-#line  1374 "cs.ATG" 
+#line  1373 "cs.ATG" 
 			op = OverloadableOperatorType.Not; 
 			break;
 		}
 		case 27: {
 			lexer.NextToken();
 
-#line  1375 "cs.ATG" 
+#line  1374 "cs.ATG" 
 			op = OverloadableOperatorType.BitNot; 
 			break;
 		}
 		case 31: {
 			lexer.NextToken();
 
-#line  1377 "cs.ATG" 
+#line  1376 "cs.ATG" 
 			op = OverloadableOperatorType.Increment; 
 			break;
 		}
 		case 32: {
 			lexer.NextToken();
 
-#line  1378 "cs.ATG" 
+#line  1377 "cs.ATG" 
 			op = OverloadableOperatorType.Decrement; 
 			break;
 		}
 		case 113: {
 			lexer.NextToken();
 
-#line  1380 "cs.ATG" 
+#line  1379 "cs.ATG" 
 			op = OverloadableOperatorType.IsTrue; 
 			break;
 		}
 		case 72: {
 			lexer.NextToken();
 
-#line  1381 "cs.ATG" 
+#line  1380 "cs.ATG" 
 			op = OverloadableOperatorType.IsFalse; 
 			break;
 		}
 		case 6: {
 			lexer.NextToken();
 
-#line  1383 "cs.ATG" 
+#line  1382 "cs.ATG" 
 			op = OverloadableOperatorType.Multiply; 
 			break;
 		}
 		case 7: {
 			lexer.NextToken();
 
-#line  1384 "cs.ATG" 
+#line  1383 "cs.ATG" 
 			op = OverloadableOperatorType.Divide; 
 			break;
 		}
 		case 8: {
 			lexer.NextToken();
 
-#line  1385 "cs.ATG" 
+#line  1384 "cs.ATG" 
 			op = OverloadableOperatorType.Modulus; 
 			break;
 		}
 		case 28: {
 			lexer.NextToken();
 
-#line  1387 "cs.ATG" 
+#line  1386 "cs.ATG" 
 			op = OverloadableOperatorType.BitwiseAnd; 
 			break;
 		}
 		case 29: {
 			lexer.NextToken();
 
-#line  1388 "cs.ATG" 
+#line  1387 "cs.ATG" 
 			op = OverloadableOperatorType.BitwiseOr; 
 			break;
 		}
 		case 30: {
 			lexer.NextToken();
 
-#line  1389 "cs.ATG" 
+#line  1388 "cs.ATG" 
 			op = OverloadableOperatorType.ExclusiveOr; 
 			break;
 		}
 		case 37: {
 			lexer.NextToken();
 
-#line  1391 "cs.ATG" 
+#line  1390 "cs.ATG" 
 			op = OverloadableOperatorType.ShiftLeft; 
 			break;
 		}
 		case 33: {
 			lexer.NextToken();
 
-#line  1392 "cs.ATG" 
+#line  1391 "cs.ATG" 
 			op = OverloadableOperatorType.Equality; 
 			break;
 		}
 		case 34: {
 			lexer.NextToken();
 
-#line  1393 "cs.ATG" 
+#line  1392 "cs.ATG" 
 			op = OverloadableOperatorType.InEquality; 
 			break;
 		}
 		case 23: {
 			lexer.NextToken();
 
-#line  1394 "cs.ATG" 
+#line  1393 "cs.ATG" 
 			op = OverloadableOperatorType.LessThan; 
 			break;
 		}
 		case 35: {
 			lexer.NextToken();
 
-#line  1395 "cs.ATG" 
+#line  1394 "cs.ATG" 
 			op = OverloadableOperatorType.GreaterThanOrEqual; 
 			break;
 		}
 		case 36: {
 			lexer.NextToken();
 
-#line  1396 "cs.ATG" 
+#line  1395 "cs.ATG" 
 			op = OverloadableOperatorType.LessThanOrEqual; 
 			break;
 		}
 		case 22: {
 			lexer.NextToken();
 
-#line  1397 "cs.ATG" 
+#line  1396 "cs.ATG" 
 			op = OverloadableOperatorType.GreaterThan; 
 			if (la.kind == 22) {
 				lexer.NextToken();
 
-#line  1397 "cs.ATG" 
+#line  1396 "cs.ATG" 
 				op = OverloadableOperatorType.ShiftRight; 
 			}
 			break;
@@ -2984,34 +2977,34 @@ out OverloadableOperatorType op) {
 	}
 
 	void VariableDeclarator(
-#line  1307 "cs.ATG" 
+#line  1306 "cs.ATG" 
 FieldDeclaration parentFieldDeclaration) {
 
-#line  1308 "cs.ATG" 
+#line  1307 "cs.ATG" 
 		Expression expr = null; 
 		Identifier();
 
-#line  1310 "cs.ATG" 
+#line  1309 "cs.ATG" 
 		VariableDeclaration f = new VariableDeclaration(t.val); f.StartLocation = t.Location; 
 		if (la.kind == 3) {
 			lexer.NextToken();
 			VariableInitializer(
-#line  1311 "cs.ATG" 
+#line  1310 "cs.ATG" 
 out expr);
 
-#line  1311 "cs.ATG" 
+#line  1310 "cs.ATG" 
 			f.Initializer = expr; 
 		}
 
-#line  1312 "cs.ATG" 
+#line  1311 "cs.ATG" 
 		f.EndLocation = t.EndLocation; SafeAdd(parentFieldDeclaration, parentFieldDeclaration.Fields, f); 
 	}
 
 	void AccessorDecls(
-#line  1199 "cs.ATG" 
+#line  1198 "cs.ATG" 
 out PropertyGetRegion getBlock, out PropertySetRegion setBlock) {
 
-#line  1201 "cs.ATG" 
+#line  1200 "cs.ATG" 
 		List<AttributeSection> attributes = new List<AttributeSection>(); 
 		AttributeSection section;
 		getBlock = null;
@@ -3020,92 +3013,92 @@ out PropertyGetRegion getBlock, out PropertySetRegion setBlock) {
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  1208 "cs.ATG" 
+#line  1207 "cs.ATG" 
 out section);
 
-#line  1208 "cs.ATG" 
+#line  1207 "cs.ATG" 
 			attributes.Add(section); 
 		}
 		if (la.kind == 84 || la.kind == 96 || la.kind == 97) {
 			AccessorModifiers(
-#line  1209 "cs.ATG" 
+#line  1208 "cs.ATG" 
 out modifiers);
 		}
 		if (la.kind == 128) {
 			GetAccessorDecl(
-#line  1211 "cs.ATG" 
+#line  1210 "cs.ATG" 
 out getBlock, attributes);
 
-#line  1212 "cs.ATG" 
+#line  1211 "cs.ATG" 
 			if (modifiers != null) {getBlock.Modifier = modifiers.Modifier; } 
-			if (StartOf(26)) {
+			if (StartOf(27)) {
 
-#line  1213 "cs.ATG" 
+#line  1212 "cs.ATG" 
 				attributes = new List<AttributeSection>(); modifiers = null; 
 				while (la.kind == 18) {
 					AttributeSection(
-#line  1214 "cs.ATG" 
+#line  1213 "cs.ATG" 
 out section);
 
-#line  1214 "cs.ATG" 
+#line  1213 "cs.ATG" 
 					attributes.Add(section); 
 				}
 				if (la.kind == 84 || la.kind == 96 || la.kind == 97) {
 					AccessorModifiers(
-#line  1215 "cs.ATG" 
+#line  1214 "cs.ATG" 
 out modifiers);
 				}
 				SetAccessorDecl(
-#line  1216 "cs.ATG" 
+#line  1215 "cs.ATG" 
 out setBlock, attributes);
 
-#line  1217 "cs.ATG" 
+#line  1216 "cs.ATG" 
 				if (modifiers != null) {setBlock.Modifier = modifiers.Modifier; } 
 			}
 		} else if (la.kind == 129) {
 			SetAccessorDecl(
-#line  1220 "cs.ATG" 
+#line  1219 "cs.ATG" 
 out setBlock, attributes);
 
-#line  1221 "cs.ATG" 
+#line  1220 "cs.ATG" 
 			if (modifiers != null) {setBlock.Modifier = modifiers.Modifier; } 
-			if (StartOf(27)) {
+			if (StartOf(28)) {
 
-#line  1222 "cs.ATG" 
+#line  1221 "cs.ATG" 
 				attributes = new List<AttributeSection>(); modifiers = null; 
 				while (la.kind == 18) {
 					AttributeSection(
-#line  1223 "cs.ATG" 
+#line  1222 "cs.ATG" 
 out section);
 
-#line  1223 "cs.ATG" 
+#line  1222 "cs.ATG" 
 					attributes.Add(section); 
 				}
 				if (la.kind == 84 || la.kind == 96 || la.kind == 97) {
 					AccessorModifiers(
-#line  1224 "cs.ATG" 
+#line  1223 "cs.ATG" 
 out modifiers);
 				}
 				GetAccessorDecl(
-#line  1225 "cs.ATG" 
+#line  1224 "cs.ATG" 
 out getBlock, attributes);
 
-#line  1226 "cs.ATG" 
+#line  1225 "cs.ATG" 
 				if (modifiers != null) {getBlock.Modifier = modifiers.Modifier; } 
 			}
 		} else if (StartOf(18)) {
 			Identifier();
 
-#line  1228 "cs.ATG" 
+#line  1227 "cs.ATG" 
 			Error("get or set accessor declaration expected"); 
 		} else SynErr(184);
 	}
 
 	void InterfaceAccessors(
-#line  1273 "cs.ATG" 
+#line  1272 "cs.ATG" 
 out PropertyGetRegion getBlock, out PropertySetRegion setBlock) {
 
-#line  1275 "cs.ATG" 
+#line  1274 "cs.ATG" 
 		AttributeSection section;
 		List<AttributeSection> attributes = new List<AttributeSection>();
 		getBlock = null; setBlock = null;
@@ -3113,218 +3106,218 @@ out PropertyGetRegion getBlock, out PropertySetRegion setBlock) {
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  1281 "cs.ATG" 
+#line  1280 "cs.ATG" 
 out section);
 
-#line  1281 "cs.ATG" 
+#line  1280 "cs.ATG" 
 			attributes.Add(section); 
 		}
 
-#line  1282 "cs.ATG" 
+#line  1281 "cs.ATG" 
 		Location startLocation = la.Location; 
 		if (la.kind == 128) {
 			lexer.NextToken();
 
-#line  1284 "cs.ATG" 
+#line  1283 "cs.ATG" 
 			getBlock = new PropertyGetRegion(null, attributes); 
 		} else if (la.kind == 129) {
 			lexer.NextToken();
 
-#line  1285 "cs.ATG" 
+#line  1284 "cs.ATG" 
 			setBlock = new PropertySetRegion(null, attributes); 
 		} else SynErr(185);
 		Expect(11);
 
-#line  1288 "cs.ATG" 
+#line  1287 "cs.ATG" 
 		if (getBlock != null) { getBlock.StartLocation = startLocation; getBlock.EndLocation = t.EndLocation; }
 		if (setBlock != null) { setBlock.StartLocation = startLocation; setBlock.EndLocation = t.EndLocation; }
 		attributes = new List<AttributeSection>(); 
 		if (la.kind == 18 || la.kind == 128 || la.kind == 129) {
 			while (la.kind == 18) {
 				AttributeSection(
-#line  1292 "cs.ATG" 
+#line  1291 "cs.ATG" 
 out section);
 
-#line  1292 "cs.ATG" 
+#line  1291 "cs.ATG" 
 				attributes.Add(section); 
 			}
 
-#line  1293 "cs.ATG" 
+#line  1292 "cs.ATG" 
 			startLocation = la.Location; 
 			if (la.kind == 128) {
 				lexer.NextToken();
 
-#line  1295 "cs.ATG" 
+#line  1294 "cs.ATG" 
 				if (getBlock != null) Error("get already declared");
 				                 else { getBlock = new PropertyGetRegion(null, attributes); lastBlock = getBlock; }
 				              
 			} else if (la.kind == 129) {
 				lexer.NextToken();
 
-#line  1298 "cs.ATG" 
+#line  1297 "cs.ATG" 
 				if (setBlock != null) Error("set already declared");
 				                 else { setBlock = new PropertySetRegion(null, attributes); lastBlock = setBlock; }
 				              
 			} else SynErr(186);
 			Expect(11);
 
-#line  1303 "cs.ATG" 
+#line  1302 "cs.ATG" 
 			if (lastBlock != null) { lastBlock.StartLocation = startLocation; lastBlock.EndLocation = t.EndLocation; } 
 		}
 	}
 
 	void GetAccessorDecl(
-#line  1232 "cs.ATG" 
+#line  1231 "cs.ATG" 
 out PropertyGetRegion getBlock, List<AttributeSection> attributes) {
 
-#line  1233 "cs.ATG" 
+#line  1232 "cs.ATG" 
 		BlockStatement stmt = null; 
 		Expect(128);
 
-#line  1236 "cs.ATG" 
+#line  1235 "cs.ATG" 
 		Location startLocation = t.Location; 
 		if (la.kind == 16) {
 			Block(
-#line  1237 "cs.ATG" 
+#line  1236 "cs.ATG" 
 out stmt);
 		} else if (la.kind == 11) {
 			lexer.NextToken();
 		} else SynErr(187);
 
-#line  1238 "cs.ATG" 
+#line  1237 "cs.ATG" 
 		getBlock = new PropertyGetRegion(stmt, attributes); 
 
-#line  1239 "cs.ATG" 
+#line  1238 "cs.ATG" 
 		getBlock.StartLocation = startLocation; getBlock.EndLocation = t.EndLocation; 
 	}
 
 	void SetAccessorDecl(
-#line  1242 "cs.ATG" 
+#line  1241 "cs.ATG" 
 out PropertySetRegion setBlock, List<AttributeSection> attributes) {
 
-#line  1243 "cs.ATG" 
+#line  1242 "cs.ATG" 
 		BlockStatement stmt = null; 
 		Expect(129);
 
-#line  1246 "cs.ATG" 
+#line  1245 "cs.ATG" 
 		Location startLocation = t.Location; 
 		if (la.kind == 16) {
 			Block(
-#line  1247 "cs.ATG" 
+#line  1246 "cs.ATG" 
 out stmt);
 		} else if (la.kind == 11) {
 			lexer.NextToken();
 		} else SynErr(188);
 
-#line  1248 "cs.ATG" 
+#line  1247 "cs.ATG" 
 		setBlock = new PropertySetRegion(stmt, attributes); 
 
-#line  1249 "cs.ATG" 
+#line  1248 "cs.ATG" 
 		setBlock.StartLocation = startLocation; setBlock.EndLocation = t.EndLocation; 
 	}
 
 	void AddAccessorDecl(
-#line  1331 "cs.ATG" 
+#line  1330 "cs.ATG" 
 out BlockStatement stmt) {
 
-#line  1332 "cs.ATG" 
+#line  1331 "cs.ATG" 
 		stmt = null;
 		Expect(130);
 		Block(
-#line  1335 "cs.ATG" 
+#line  1334 "cs.ATG" 
 out stmt);
 	}
 
 	void RemoveAccessorDecl(
-#line  1338 "cs.ATG" 
+#line  1337 "cs.ATG" 
 out BlockStatement stmt) {
 
-#line  1339 "cs.ATG" 
+#line  1338 "cs.ATG" 
 		stmt = null;
 		Expect(131);
 		Block(
-#line  1342 "cs.ATG" 
+#line  1341 "cs.ATG" 
 out stmt);
 	}
 
 	void VariableInitializer(
-#line  1360 "cs.ATG" 
+#line  1359 "cs.ATG" 
 out Expression initializerExpression) {
 
-#line  1361 "cs.ATG" 
+#line  1360 "cs.ATG" 
 		TypeReference type = null; Expression expr = null; initializerExpression = null; 
 		if (StartOf(6)) {
 			Expr(
-#line  1363 "cs.ATG" 
+#line  1362 "cs.ATG" 
 out initializerExpression);
 		} else if (la.kind == 16) {
 			CollectionInitializer(
-#line  1364 "cs.ATG" 
+#line  1363 "cs.ATG" 
 out initializerExpression);
 		} else if (la.kind == 106) {
 			lexer.NextToken();
 			Type(
-#line  1365 "cs.ATG" 
+#line  1364 "cs.ATG" 
 out type);
 			Expect(18);
 			Expr(
-#line  1365 "cs.ATG" 
+#line  1364 "cs.ATG" 
 out expr);
 			Expect(19);
 
-#line  1365 "cs.ATG" 
+#line  1364 "cs.ATG" 
 			initializerExpression = new StackAllocExpression(type, expr); 
 		} else SynErr(189);
 	}
 
 	void Statement() {
 
-#line  1522 "cs.ATG" 
+#line  1521 "cs.ATG" 
 		Statement stmt = null;
 		Location startPos = la.Location;
 		
-		while (!(StartOf(28))) {SynErr(190); lexer.NextToken(); }
+		while (!(StartOf(29))) {SynErr(190); lexer.NextToken(); }
 		if (
-#line  1529 "cs.ATG" 
+#line  1528 "cs.ATG" 
 IsLabel()) {
 			Identifier();
 
-#line  1529 "cs.ATG" 
+#line  1528 "cs.ATG" 
 			AddChild(new LabelStatement(t.val)); 
 			Expect(9);
 			Statement();
 		} else if (la.kind == 60) {
 			lexer.NextToken();
 			LocalVariableDecl(
-#line  1533 "cs.ATG" 
+#line  1532 "cs.ATG" 
 out stmt);
 
-#line  1534 "cs.ATG" 
+#line  1533 "cs.ATG" 
 			if (stmt != null) { ((LocalVariableDeclaration)stmt).Modifier |= Modifiers.Const; } 
 			Expect(11);
 
-#line  1535 "cs.ATG" 
+#line  1534 "cs.ATG" 
 			AddChild(stmt); 
 		} else if (
-#line  1537 "cs.ATG" 
+#line  1536 "cs.ATG" 
 IsLocalVarDecl()) {
 			LocalVariableDecl(
-#line  1537 "cs.ATG" 
+#line  1536 "cs.ATG" 
 out stmt);
 			Expect(11);
 
-#line  1537 "cs.ATG" 
+#line  1536 "cs.ATG" 
 			AddChild(stmt); 
-		} else if (StartOf(29)) {
+		} else if (StartOf(30)) {
 			EmbeddedStatement(
-#line  1539 "cs.ATG" 
+#line  1538 "cs.ATG" 
 out stmt);
 
-#line  1539 "cs.ATG" 
+#line  1538 "cs.ATG" 
 			AddChild(stmt); 
 		} else SynErr(191);
 
-#line  1545 "cs.ATG" 
+#line  1544 "cs.ATG" 
 		if (stmt != null) {
 		stmt.StartLocation = startPos;
 		stmt.EndLocation = t.EndLocation;
@@ -3333,63 +3326,63 @@ out stmt);
 	}
 
 	void Argument(
-#line  1400 "cs.ATG" 
+#line  1399 "cs.ATG" 
 out Expression argumentexpr) {
 
-#line  1401 "cs.ATG" 
+#line  1400 "cs.ATG" 
 		argumentexpr = null; 
 		if (
-#line  1403 "cs.ATG" 
+#line  1402 "cs.ATG" 
 IdentAndColon()) {
 
-#line  1404 "cs.ATG" 
+#line  1403 "cs.ATG" 
 			Token ident; Expression expr; 
 			Identifier();
 
-#line  1405 "cs.ATG" 
+#line  1404 "cs.ATG" 
 			ident = t; 
 			Expect(9);
 			ArgumentValue(
-#line  1407 "cs.ATG" 
+#line  1406 "cs.ATG" 
 out expr);
 
-#line  1408 "cs.ATG" 
+#line  1407 "cs.ATG" 
 			argumentexpr = new NamedArgumentExpression(ident.val, expr) { StartLocation = ident.Location, EndLocation = t.EndLocation }; 
-		} else if (StartOf(25)) {
+		} else if (StartOf(26)) {
 			ArgumentValue(
-#line  1410 "cs.ATG" 
+#line  1409 "cs.ATG" 
 out argumentexpr);
 		} else SynErr(192);
 	}
 
 	void CollectionInitializer(
-#line  1444 "cs.ATG" 
+#line  1443 "cs.ATG" 
 out Expression outExpr) {
 
-#line  1446 "cs.ATG" 
+#line  1445 "cs.ATG" 
 		Expression expr = null;
 		CollectionInitializerExpression initializer = new CollectionInitializerExpression();
 		
 		Expect(16);
 
-#line  1450 "cs.ATG" 
+#line  1449 "cs.ATG" 
 		initializer.StartLocation = t.Location; 
-		if (StartOf(30)) {
+		if (StartOf(31)) {
 			VariableInitializer(
-#line  1451 "cs.ATG" 
+#line  1450 "cs.ATG" 
 out expr);
 
-#line  1452 "cs.ATG" 
+#line  1451 "cs.ATG" 
 			SafeAdd(initializer, initializer.CreateExpressions, expr); 
 			while (
-#line  1453 "cs.ATG" 
+#line  1452 "cs.ATG" 
 NotFinalComma()) {
 				Expect(14);
 				VariableInitializer(
-#line  1454 "cs.ATG" 
+#line  1453 "cs.ATG" 
 out expr);
 
-#line  1455 "cs.ATG" 
+#line  1454 "cs.ATG" 
 				SafeAdd(initializer, initializer.CreateExpressions, expr); 
 			}
 			if (la.kind == 14) {
@@ -3398,15 +3391,15 @@ out expr);
 		}
 		Expect(17);
 
-#line  1459 "cs.ATG" 
+#line  1458 "cs.ATG" 
 		initializer.EndLocation = t.Location; outExpr = initializer; 
 	}
 
 	void ArgumentValue(
-#line  1413 "cs.ATG" 
+#line  1412 "cs.ATG" 
 out Expression argumentexpr) {
 
-#line  1415 "cs.ATG" 
+#line  1414 "cs.ATG" 
 		Expression expr;
 		FieldDirection fd = FieldDirection.None;
 		
@@ -3414,118 +3407,118 @@ out Expression argumentexpr) {
 			if (la.kind == 100) {
 				lexer.NextToken();
 
-#line  1420 "cs.ATG" 
+#line  1419 "cs.ATG" 
 				fd = FieldDirection.Ref; 
 			} else {
 				lexer.NextToken();
 
-#line  1421 "cs.ATG" 
+#line  1420 "cs.ATG" 
 				fd = FieldDirection.Out; 
 			}
 		}
 		Expr(
-#line  1423 "cs.ATG" 
+#line  1422 "cs.ATG" 
 out expr);
 
-#line  1424 "cs.ATG" 
+#line  1423 "cs.ATG" 
 		argumentexpr = fd != FieldDirection.None ? argumentexpr = new DirectionExpression(fd, expr) : expr; 
 	}
 
 	void AssignmentOperator(
-#line  1427 "cs.ATG" 
+#line  1426 "cs.ATG" 
 out AssignmentOperatorType op) {
 
-#line  1428 "cs.ATG" 
+#line  1427 "cs.ATG" 
 		op = AssignmentOperatorType.None; 
 		if (la.kind == 3) {
 			lexer.NextToken();
 
-#line  1430 "cs.ATG" 
+#line  1429 "cs.ATG" 
 			op = AssignmentOperatorType.Assign; 
 		} else if (la.kind == 38) {
 			lexer.NextToken();
 
-#line  1431 "cs.ATG" 
+#line  1430 "cs.ATG" 
 			op = AssignmentOperatorType.Add; 
 		} else if (la.kind == 39) {
 			lexer.NextToken();
 
-#line  1432 "cs.ATG" 
+#line  1431 "cs.ATG" 
 			op = AssignmentOperatorType.Subtract; 
 		} else if (la.kind == 40) {
 			lexer.NextToken();
 
-#line  1433 "cs.ATG" 
+#line  1432 "cs.ATG" 
 			op = AssignmentOperatorType.Multiply; 
 		} else if (la.kind == 41) {
 			lexer.NextToken();
 
-#line  1434 "cs.ATG" 
+#line  1433 "cs.ATG" 
 			op = AssignmentOperatorType.Divide; 
 		} else if (la.kind == 42) {
 			lexer.NextToken();
 
-#line  1435 "cs.ATG" 
+#line  1434 "cs.ATG" 
 			op = AssignmentOperatorType.Modulus; 
 		} else if (la.kind == 43) {
 			lexer.NextToken();
 
-#line  1436 "cs.ATG" 
+#line  1435 "cs.ATG" 
 			op = AssignmentOperatorType.BitwiseAnd; 
 		} else if (la.kind == 44) {
 			lexer.NextToken();
 
-#line  1437 "cs.ATG" 
+#line  1436 "cs.ATG" 
 			op = AssignmentOperatorType.BitwiseOr; 
 		} else if (la.kind == 45) {
 			lexer.NextToken();
 
-#line  1438 "cs.ATG" 
+#line  1437 "cs.ATG" 
 			op = AssignmentOperatorType.ExclusiveOr; 
 		} else if (la.kind == 46) {
 			lexer.NextToken();
 
-#line  1439 "cs.ATG" 
+#line  1438 "cs.ATG" 
 			op = AssignmentOperatorType.ShiftLeft; 
 		} else if (
-#line  1440 "cs.ATG" 
+#line  1439 "cs.ATG" 
 la.kind == Tokens.GreaterThan && Peek(1).kind == Tokens.GreaterEqual) {
 			Expect(22);
 			Expect(35);
 
-#line  1441 "cs.ATG" 
+#line  1440 "cs.ATG" 
 			op = AssignmentOperatorType.ShiftRight; 
 		} else SynErr(193);
 	}
 
 	void CollectionOrObjectInitializer(
-#line  1462 "cs.ATG" 
+#line  1461 "cs.ATG" 
 out Expression outExpr) {
 
-#line  1464 "cs.ATG" 
+#line  1463 "cs.ATG" 
 		Expression expr = null;
 		CollectionInitializerExpression initializer = new CollectionInitializerExpression();
 		
 		Expect(16);
 
-#line  1468 "cs.ATG" 
+#line  1467 "cs.ATG" 
 		initializer.StartLocation = t.Location; 
-		if (StartOf(30)) {
+		if (StartOf(31)) {
 			ObjectPropertyInitializerOrVariableInitializer(
-#line  1469 "cs.ATG" 
+#line  1468 "cs.ATG" 
 out expr);
 
-#line  1470 "cs.ATG" 
+#line  1469 "cs.ATG" 
 			SafeAdd(initializer, initializer.CreateExpressions, expr); 
 			while (
-#line  1471 "cs.ATG" 
+#line  1470 "cs.ATG" 
 NotFinalComma()) {
 				Expect(14);
 				ObjectPropertyInitializerOrVariableInitializer(
-#line  1472 "cs.ATG" 
+#line  1471 "cs.ATG" 
 out expr);
 
-#line  1473 "cs.ATG" 
+#line  1472 "cs.ATG" 
 				SafeAdd(initializer, initializer.CreateExpressions, expr); 
 			}
 			if (la.kind == 14) {
@@ -3534,22 +3527,22 @@ out expr);
 		}
 		Expect(17);
 
-#line  1477 "cs.ATG" 
+#line  1476 "cs.ATG" 
 		initializer.EndLocation = t.Location; outExpr = initializer; 
 	}
 
 	void ObjectPropertyInitializerOrVariableInitializer(
-#line  1480 "cs.ATG" 
+#line  1479 "cs.ATG" 
 out Expression expr) {
 
-#line  1481 "cs.ATG" 
+#line  1480 "cs.ATG" 
 		expr = null; 
 		if (
-#line  1483 "cs.ATG" 
+#line  1482 "cs.ATG" 
 IdentAndAsgn()) {
 			Identifier();
 
-#line  1485 "cs.ATG" 
+#line  1484 "cs.ATG" 
 			MemberInitializerExpression mie = new MemberInitializerExpression(t.val, null);
 			mie.StartLocation = t.Location;
 			mie.IsKey = true;
@@ -3557,88 +3550,88 @@ IdentAndAsgn()) {
 			Expect(3);
 			if (la.kind == 16) {
 				CollectionOrObjectInitializer(
-#line  1490 "cs.ATG" 
+#line  1489 "cs.ATG" 
 out r);
-			} else if (StartOf(30)) {
+			} else if (StartOf(31)) {
 				VariableInitializer(
-#line  1491 "cs.ATG" 
+#line  1490 "cs.ATG" 
 out r);
 			} else SynErr(194);
 
-#line  1492 "cs.ATG" 
+#line  1491 "cs.ATG" 
 			mie.Expression = r; mie.EndLocation = t.EndLocation; expr = mie; 
-		} else if (StartOf(30)) {
+		} else if (StartOf(31)) {
 			VariableInitializer(
-#line  1494 "cs.ATG" 
+#line  1493 "cs.ATG" 
 out expr);
 		} else SynErr(195);
 	}
 
 	void LocalVariableDecl(
-#line  1498 "cs.ATG" 
+#line  1497 "cs.ATG" 
 out Statement stmt) {
 
-#line  1500 "cs.ATG" 
+#line  1499 "cs.ATG" 
 		TypeReference type;
 		VariableDeclaration      var = null;
 		LocalVariableDeclaration localVariableDeclaration; 
 		Location startPos = la.Location;
 		
 		Type(
-#line  1506 "cs.ATG" 
+#line  1505 "cs.ATG" 
 out type);
 
-#line  1506 "cs.ATG" 
+#line  1505 "cs.ATG" 
 		localVariableDeclaration = new LocalVariableDeclaration(type); localVariableDeclaration.StartLocation = startPos; 
 		LocalVariableDeclarator(
-#line  1507 "cs.ATG" 
+#line  1506 "cs.ATG" 
 out var);
 
-#line  1507 "cs.ATG" 
+#line  1506 "cs.ATG" 
 		SafeAdd(localVariableDeclaration, localVariableDeclaration.Variables, var); 
 		while (la.kind == 14) {
 			lexer.NextToken();
 			LocalVariableDeclarator(
-#line  1508 "cs.ATG" 
+#line  1507 "cs.ATG" 
 out var);
 
-#line  1508 "cs.ATG" 
+#line  1507 "cs.ATG" 
 			SafeAdd(localVariableDeclaration, localVariableDeclaration.Variables, var); 
 		}
 
-#line  1509 "cs.ATG" 
+#line  1508 "cs.ATG" 
 		stmt = localVariableDeclaration; stmt.EndLocation = t.EndLocation; 
 	}
 
 	void LocalVariableDeclarator(
-#line  1512 "cs.ATG" 
+#line  1511 "cs.ATG" 
 out VariableDeclaration var) {
 
-#line  1513 "cs.ATG" 
+#line  1512 "cs.ATG" 
 		Expression expr = null; 
 		Identifier();
 
-#line  1515 "cs.ATG" 
+#line  1514 "cs.ATG" 
 		var = new VariableDeclaration(t.val); var.StartLocation = t.Location; 
 		if (la.kind == 3) {
 			lexer.NextToken();
 			VariableInitializer(
-#line  1516 "cs.ATG" 
+#line  1515 "cs.ATG" 
 out expr);
 
-#line  1516 "cs.ATG" 
+#line  1515 "cs.ATG" 
 			var.Initializer = expr; 
 		}
 
-#line  1517 "cs.ATG" 
+#line  1516 "cs.ATG" 
 		var.EndLocation = t.EndLocation; 
 	}
 
 	void EmbeddedStatement(
-#line  1552 "cs.ATG" 
+#line  1551 "cs.ATG" 
 out Statement statement) {
 
-#line  1554 "cs.ATG" 
+#line  1553 "cs.ATG" 
 		TypeReference type = null;
 		Expression expr = null;
 		Statement embeddedStatement = null;
@@ -3646,173 +3639,173 @@ out Statement statement) {
 		statement = null;
 		
 
-#line  1561 "cs.ATG" 
+#line  1560 "cs.ATG" 
 		Location startLocation = la.Location; 
 		if (la.kind == 16) {
 			Block(
-#line  1563 "cs.ATG" 
+#line  1562 "cs.ATG" 
 out block);
 
-#line  1563 "cs.ATG" 
+#line  1562 "cs.ATG" 
 			statement = block; 
 		} else if (la.kind == 11) {
 			lexer.NextToken();
 
-#line  1566 "cs.ATG" 
+#line  1565 "cs.ATG" 
 			statement = new EmptyStatement(); 
 		} else if (
-#line  1569 "cs.ATG" 
+#line  1568 "cs.ATG" 
 UnCheckedAndLBrace()) {
 
-#line  1569 "cs.ATG" 
+#line  1568 "cs.ATG" 
 			bool isChecked = true; 
 			if (la.kind == 58) {
 				lexer.NextToken();
 			} else if (la.kind == 118) {
 				lexer.NextToken();
 
-#line  1570 "cs.ATG" 
+#line  1569 "cs.ATG" 
 				isChecked = false;
 			} else SynErr(196);
 			Block(
-#line  1571 "cs.ATG" 
+#line  1570 "cs.ATG" 
 out block);
 
-#line  1571 "cs.ATG" 
+#line  1570 "cs.ATG" 
 			statement = isChecked ? (Statement)new CheckedStatement(block) : (Statement)new UncheckedStatement(block); 
 		} else if (la.kind == 79) {
 			IfStatement(
-#line  1574 "cs.ATG" 
+#line  1573 "cs.ATG" 
 out statement);
 		} else if (la.kind == 110) {
 			lexer.NextToken();
 
-#line  1576 "cs.ATG" 
+#line  1575 "cs.ATG" 
 			List<SwitchSection> switchSections = new List<SwitchSection>(); 
 			Expect(20);
 			Expr(
-#line  1577 "cs.ATG" 
+#line  1576 "cs.ATG" 
 out expr);
 			Expect(21);
 			Expect(16);
 			SwitchSections(
-#line  1578 "cs.ATG" 
+#line  1577 "cs.ATG" 
 switchSections);
 			Expect(17);
 
-#line  1580 "cs.ATG" 
+#line  1579 "cs.ATG" 
 			statement = new SwitchStatement(expr, switchSections); 
 		} else if (la.kind == 125) {
 			lexer.NextToken();
 			Expect(20);
 			Expr(
-#line  1583 "cs.ATG" 
+#line  1582 "cs.ATG" 
 out expr);
 			Expect(21);
 			EmbeddedStatement(
-#line  1584 "cs.ATG" 
+#line  1583 "cs.ATG" 
 out embeddedStatement);
 
-#line  1585 "cs.ATG" 
+#line  1584 "cs.ATG" 
 			statement = new DoLoopStatement(expr, embeddedStatement, ConditionType.While, ConditionPosition.Start);
 		} else if (la.kind == 65) {
 			lexer.NextToken();
 			EmbeddedStatement(
-#line  1587 "cs.ATG" 
+#line  1586 "cs.ATG" 
 out embeddedStatement);
 			Expect(125);
 			Expect(20);
 			Expr(
-#line  1588 "cs.ATG" 
+#line  1587 "cs.ATG" 
 out expr);
 			Expect(21);
 			Expect(11);
 
-#line  1589 "cs.ATG" 
+#line  1588 "cs.ATG" 
 			statement = new DoLoopStatement(expr, embeddedStatement, ConditionType.While, ConditionPosition.End); 
 		} else if (la.kind == 76) {
 			lexer.NextToken();
 
-#line  1591 "cs.ATG" 
+#line  1590 "cs.ATG" 
 			List<Statement> initializer = null; List<Statement> iterator = null; 
 			Expect(20);
 			if (StartOf(6)) {
 				ForInitializer(
-#line  1592 "cs.ATG" 
+#line  1591 "cs.ATG" 
 out initializer);
 			}
 			Expect(11);
 			if (StartOf(6)) {
 				Expr(
-#line  1593 "cs.ATG" 
+#line  1592 "cs.ATG" 
 out expr);
 			}
 			Expect(11);
 			if (StartOf(6)) {
 				ForIterator(
-#line  1594 "cs.ATG" 
+#line  1593 "cs.ATG" 
 out iterator);
 			}
 			Expect(21);
 			EmbeddedStatement(
-#line  1595 "cs.ATG" 
+#line  1594 "cs.ATG" 
 out embeddedStatement);
 
-#line  1596 "cs.ATG" 
+#line  1595 "cs.ATG" 
 			statement = new ForStatement(initializer, expr, iterator, embeddedStatement); 
 		} else if (la.kind == 77) {
 			lexer.NextToken();
 			Expect(20);
 			Type(
-#line  1598 "cs.ATG" 
+#line  1597 "cs.ATG" 
 out type);
 			Identifier();
 
-#line  1598 "cs.ATG" 
+#line  1597 "cs.ATG" 
 			string varName = t.val; 
 			Expect(81);
 			Expr(
-#line  1599 "cs.ATG" 
+#line  1598 "cs.ATG" 
 out expr);
 			Expect(21);
 			EmbeddedStatement(
-#line  1600 "cs.ATG" 
+#line  1599 "cs.ATG" 
 out embeddedStatement);
 
-#line  1601 "cs.ATG" 
+#line  1600 "cs.ATG" 
 			statement = new ForeachStatement(type, varName , expr, embeddedStatement); 
 		} else if (la.kind == 53) {
 			lexer.NextToken();
 			Expect(11);
 
-#line  1604 "cs.ATG" 
+#line  1603 "cs.ATG" 
 			statement = new BreakStatement(); 
 		} else if (la.kind == 61) {
 			lexer.NextToken();
 			Expect(11);
 
-#line  1605 "cs.ATG" 
+#line  1604 "cs.ATG" 
 			statement = new ContinueStatement(); 
 		} else if (la.kind == 78) {
 			GotoStatement(
-#line  1606 "cs.ATG" 
+#line  1605 "cs.ATG" 
 out statement);
 		} else if (
-#line  1608 "cs.ATG" 
+#line  1607 "cs.ATG" 
 IsYieldStatement()) {
 			Expect(132);
 			if (la.kind == 101) {
 				lexer.NextToken();
 				Expr(
-#line  1609 "cs.ATG" 
+#line  1608 "cs.ATG" 
 out expr);
 
-#line  1609 "cs.ATG" 
+#line  1608 "cs.ATG" 
 				statement = new YieldStatement(new ReturnStatement(expr)); 
 			} else if (la.kind == 53) {
 				lexer.NextToken();
 
-#line  1610 "cs.ATG" 
+#line  1609 "cs.ATG" 
 				statement = new YieldStatement(new BreakStatement()); 
 			} else SynErr(197);
 			Expect(11);
@@ -3820,90 +3813,90 @@ out expr);
 			lexer.NextToken();
 			if (StartOf(6)) {
 				Expr(
-#line  1613 "cs.ATG" 
+#line  1612 "cs.ATG" 
 out expr);
 			}
 			Expect(11);
 
-#line  1613 "cs.ATG" 
+#line  1612 "cs.ATG" 
 			statement = new ReturnStatement(expr); 
 		} else if (la.kind == 112) {
 			lexer.NextToken();
 			if (StartOf(6)) {
 				Expr(
-#line  1614 "cs.ATG" 
+#line  1613 "cs.ATG" 
 out expr);
 			}
 			Expect(11);
 
-#line  1614 "cs.ATG" 
+#line  1613 "cs.ATG" 
 			statement = new ThrowStatement(expr); 
 		} else if (StartOf(6)) {
 			StatementExpr(
-#line  1617 "cs.ATG" 
+#line  1616 "cs.ATG" 
 out statement);
 			while (!(la.kind == 0 || la.kind == 11)) {SynErr(198); lexer.NextToken(); }
 			Expect(11);
 		} else if (la.kind == 114) {
 			TryStatement(
-#line  1620 "cs.ATG" 
+#line  1619 "cs.ATG" 
 out statement);
 		} else if (la.kind == 86) {
 			lexer.NextToken();
 			Expect(20);
 			Expr(
-#line  1623 "cs.ATG" 
+#line  1622 "cs.ATG" 
 out expr);
 			Expect(21);
 			EmbeddedStatement(
-#line  1624 "cs.ATG" 
+#line  1623 "cs.ATG" 
 out embeddedStatement);
 
-#line  1624 "cs.ATG" 
+#line  1623 "cs.ATG" 
 			statement = new LockStatement(expr, embeddedStatement); 
 		} else if (la.kind == 121) {
 
-#line  1627 "cs.ATG" 
+#line  1626 "cs.ATG" 
 			Statement resourceAcquisitionStmt = null; 
 			lexer.NextToken();
 			Expect(20);
 			ResourceAcquisition(
-#line  1629 "cs.ATG" 
+#line  1628 "cs.ATG" 
 out resourceAcquisitionStmt);
 			Expect(21);
 			EmbeddedStatement(
-#line  1630 "cs.ATG" 
+#line  1629 "cs.ATG" 
 out embeddedStatement);
 
-#line  1630 "cs.ATG" 
+#line  1629 "cs.ATG" 
 			statement = new UsingStatement(resourceAcquisitionStmt, embeddedStatement); 
 		} else if (la.kind == 119) {
 			lexer.NextToken();
 			Block(
-#line  1633 "cs.ATG" 
+#line  1632 "cs.ATG" 
 out block);
 
-#line  1633 "cs.ATG" 
+#line  1632 "cs.ATG" 
 			statement = new UnsafeStatement(block); 
 		} else if (la.kind == 74) {
 
-#line  1635 "cs.ATG" 
+#line  1634 "cs.ATG" 
 			Statement pointerDeclarationStmt = null; 
 			lexer.NextToken();
 			Expect(20);
 			ResourceAcquisition(
-#line  1637 "cs.ATG" 
+#line  1636 "cs.ATG" 
 out pointerDeclarationStmt);
 			Expect(21);
 			EmbeddedStatement(
-#line  1638 "cs.ATG" 
+#line  1637 "cs.ATG" 
 out embeddedStatement);
 
-#line  1638 "cs.ATG" 
+#line  1637 "cs.ATG" 
 			statement = new FixedStatement(pointerDeclarationStmt, embeddedStatement); 
 		} else SynErr(199);
 
-#line  1640 "cs.ATG" 
+#line  1639 "cs.ATG" 
 		if (statement != null) {
 		statement.StartLocation = startLocation;
 		statement.EndLocation = t.EndLocation;
@@ -3912,10 +3905,10 @@ out embeddedStatement);
 	}
 
 	void IfStatement(
-#line  1647 "cs.ATG" 
+#line  1646 "cs.ATG" 
 out Statement statement) {
 
-#line  1649 "cs.ATG" 
+#line  1648 "cs.ATG" 
 		Expression expr = null;
 		Statement embeddedStatement = null;
 		statement = null;
@@ -3923,26 +3916,26 @@ out Statement statement) {
 		Expect(79);
 		Expect(20);
 		Expr(
-#line  1655 "cs.ATG" 
+#line  1654 "cs.ATG" 
 out expr);
 		Expect(21);
 		EmbeddedStatement(
-#line  1656 "cs.ATG" 
+#line  1655 "cs.ATG" 
 out embeddedStatement);
 
-#line  1657 "cs.ATG" 
+#line  1656 "cs.ATG" 
 		Statement elseStatement = null; 
 		if (la.kind == 67) {
 			lexer.NextToken();
 			EmbeddedStatement(
-#line  1658 "cs.ATG" 
+#line  1657 "cs.ATG" 
 out elseStatement);
 		}
 
-#line  1659 "cs.ATG" 
+#line  1658 "cs.ATG" 
 		statement = elseStatement != null ? new IfElseStatement(expr, embeddedStatement, elseStatement) : new IfElseStatement(expr, embeddedStatement); 
 
-#line  1660 "cs.ATG" 
+#line  1659 "cs.ATG" 
 		if (elseStatement is IfElseStatement && (elseStatement as IfElseStatement).TrueStatement.Count == 1) {
 		/* else if-section (otherwise we would have a BlockStatment) */
 		(statement as IfElseStatement).ElseIfSections.Add(
@@ -3955,29 +3948,29 @@ out elseStatement);
 	}
 
 	void SwitchSections(
-#line  1690 "cs.ATG" 
+#line  1689 "cs.ATG" 
 List<SwitchSection> switchSections) {
 
-#line  1692 "cs.ATG" 
+#line  1691 "cs.ATG" 
 		SwitchSection switchSection = new SwitchSection();
 		CaseLabel label;
 		
 		SwitchLabel(
-#line  1696 "cs.ATG" 
+#line  1695 "cs.ATG" 
 out label);
 
-#line  1696 "cs.ATG" 
+#line  1695 "cs.ATG" 
 		SafeAdd(switchSection, switchSection.SwitchLabels, label); 
 
-#line  1697 "cs.ATG" 
+#line  1696 "cs.ATG" 
 		BlockStart(switchSection); 
-		while (StartOf(31)) {
+		while (StartOf(32)) {
 			if (la.kind == 55 || la.kind == 63) {
 				SwitchLabel(
-#line  1699 "cs.ATG" 
+#line  1698 "cs.ATG" 
 out label);
 
-#line  1700 "cs.ATG" 
+#line  1699 "cs.ATG" 
 				if (label != null) {
 				if (switchSection.Children.Count > 0) {
 					// open new section
@@ -3993,145 +3986,145 @@ out label);
 			}
 		}
 
-#line  1712 "cs.ATG" 
+#line  1711 "cs.ATG" 
 		BlockEnd(); switchSections.Add(switchSection); 
 	}
 
 	void ForInitializer(
-#line  1671 "cs.ATG" 
+#line  1670 "cs.ATG" 
 out List<Statement> initializer) {
 
-#line  1673 "cs.ATG" 
+#line  1672 "cs.ATG" 
 		Statement stmt; 
 		initializer = new List<Statement>();
 		
 		if (
-#line  1677 "cs.ATG" 
+#line  1676 "cs.ATG" 
 IsLocalVarDecl()) {
 			LocalVariableDecl(
-#line  1677 "cs.ATG" 
+#line  1676 "cs.ATG" 
 out stmt);
 
-#line  1677 "cs.ATG" 
+#line  1676 "cs.ATG" 
 			initializer.Add(stmt);
 		} else if (StartOf(6)) {
 			StatementExpr(
-#line  1678 "cs.ATG" 
+#line  1677 "cs.ATG" 
 out stmt);
 
-#line  1678 "cs.ATG" 
+#line  1677 "cs.ATG" 
 			initializer.Add(stmt);
 			while (la.kind == 14) {
 				lexer.NextToken();
 				StatementExpr(
-#line  1678 "cs.ATG" 
+#line  1677 "cs.ATG" 
 out stmt);
 
-#line  1678 "cs.ATG" 
+#line  1677 "cs.ATG" 
 				initializer.Add(stmt);
 			}
 		} else SynErr(200);
 	}
 
 	void ForIterator(
-#line  1681 "cs.ATG" 
+#line  1680 "cs.ATG" 
 out List<Statement> iterator) {
 
-#line  1683 "cs.ATG" 
+#line  1682 "cs.ATG" 
 		Statement stmt; 
 		iterator = new List<Statement>();
 		
 		StatementExpr(
-#line  1687 "cs.ATG" 
+#line  1686 "cs.ATG" 
 out stmt);
 
-#line  1687 "cs.ATG" 
+#line  1686 "cs.ATG" 
 		iterator.Add(stmt);
 		while (la.kind == 14) {
 			lexer.NextToken();
 			StatementExpr(
-#line  1687 "cs.ATG" 
+#line  1686 "cs.ATG" 
 out stmt);
 
-#line  1687 "cs.ATG" 
+#line  1686 "cs.ATG" 
 			iterator.Add(stmt); 
 		}
 	}
 
 	void GotoStatement(
-#line  1769 "cs.ATG" 
+#line  1768 "cs.ATG" 
 out Statement stmt) {
 
-#line  1770 "cs.ATG" 
+#line  1769 "cs.ATG" 
 		Expression expr; stmt = null; 
 		Expect(78);
 		if (StartOf(18)) {
 			Identifier();
 
-#line  1774 "cs.ATG" 
+#line  1773 "cs.ATG" 
 			stmt = new GotoStatement(t.val); 
 			Expect(11);
 		} else if (la.kind == 55) {
 			lexer.NextToken();
 			Expr(
-#line  1775 "cs.ATG" 
+#line  1774 "cs.ATG" 
 out expr);
 			Expect(11);
 
-#line  1775 "cs.ATG" 
+#line  1774 "cs.ATG" 
 			stmt = new GotoCaseStatement(expr); 
 		} else if (la.kind == 63) {
 			lexer.NextToken();
 			Expect(11);
 
-#line  1776 "cs.ATG" 
+#line  1775 "cs.ATG" 
 			stmt = new GotoCaseStatement(null); 
 		} else SynErr(201);
 	}
 
 	void StatementExpr(
-#line  1796 "cs.ATG" 
+#line  1795 "cs.ATG" 
 out Statement stmt) {
 
-#line  1797 "cs.ATG" 
+#line  1796 "cs.ATG" 
 		Expression expr; 
 		Expr(
-#line  1799 "cs.ATG" 
+#line  1798 "cs.ATG" 
 out expr);
 
-#line  1802 "cs.ATG" 
+#line  1801 "cs.ATG" 
 		stmt = new ExpressionStatement(expr); 
 	}
 
 	void TryStatement(
-#line  1722 "cs.ATG" 
+#line  1721 "cs.ATG" 
 out Statement tryStatement) {
 
-#line  1724 "cs.ATG" 
+#line  1723 "cs.ATG" 
 		BlockStatement blockStmt = null, finallyStmt = null;
 		CatchClause catchClause = null;
 		List<CatchClause> catchClauses = new List<CatchClause>();
 		
 		Expect(114);
 		Block(
-#line  1729 "cs.ATG" 
+#line  1728 "cs.ATG" 
 out blockStmt);
 		while (la.kind == 56) {
 			CatchClause(
-#line  1731 "cs.ATG" 
+#line  1730 "cs.ATG" 
 out catchClause);
 
-#line  1732 "cs.ATG" 
+#line  1731 "cs.ATG" 
 			if (catchClause != null) catchClauses.Add(catchClause); 
 		}
 		if (la.kind == 73) {
 			lexer.NextToken();
 			Block(
-#line  1734 "cs.ATG" 
+#line  1733 "cs.ATG" 
 out finallyStmt);
 		}
 
-#line  1736 "cs.ATG" 
+#line  1735 "cs.ATG" 
 		tryStatement = new TryCatchStatement(blockStmt, catchClauses, finallyStmt);
 		if (catchClauses != null) {
 			foreach (CatchClause cc in catchClauses) cc.Parent = tryStatement;
@@ -4140,59 +4133,59 @@ out finallyStmt);
 	}
 
 	void ResourceAcquisition(
-#line  1780 "cs.ATG" 
+#line  1779 "cs.ATG" 
 out Statement stmt) {
 
-#line  1782 "cs.ATG" 
+#line  1781 "cs.ATG" 
 		stmt = null;
 		Expression expr;
 		
 		if (
-#line  1787 "cs.ATG" 
+#line  1786 "cs.ATG" 
 IsLocalVarDecl()) {
 			LocalVariableDecl(
-#line  1787 "cs.ATG" 
+#line  1786 "cs.ATG" 
 out stmt);
 		} else if (StartOf(6)) {
 			Expr(
-#line  1788 "cs.ATG" 
+#line  1787 "cs.ATG" 
 out expr);
 
-#line  1792 "cs.ATG" 
+#line  1791 "cs.ATG" 
 			stmt = new ExpressionStatement(expr); 
 		} else SynErr(202);
 	}
 
 	void SwitchLabel(
-#line  1715 "cs.ATG" 
+#line  1714 "cs.ATG" 
 out CaseLabel label) {
 
-#line  1716 "cs.ATG" 
+#line  1715 "cs.ATG" 
 		Expression expr = null; label = null; 
 		if (la.kind == 55) {
 			lexer.NextToken();
 			Expr(
-#line  1718 "cs.ATG" 
+#line  1717 "cs.ATG" 
 out expr);
 			Expect(9);
 
-#line  1718 "cs.ATG" 
+#line  1717 "cs.ATG" 
 			label =  new CaseLabel(expr); 
 		} else if (la.kind == 63) {
 			lexer.NextToken();
 			Expect(9);
 
-#line  1719 "cs.ATG" 
+#line  1718 "cs.ATG" 
 			label =  new CaseLabel(); 
 		} else SynErr(203);
 	}
 
 	void CatchClause(
-#line  1743 "cs.ATG" 
+#line  1742 "cs.ATG" 
 out CatchClause catchClause) {
 		Expect(56);
 
-#line  1745 "cs.ATG" 
+#line  1744 "cs.ATG" 
 		string identifier;
 		BlockStatement stmt;
 		TypeReference typeRef;
@@ -4201,35 +4194,35 @@ out CatchClause catchClause) {
 		
 		if (la.kind == 16) {
 			Block(
-#line  1753 "cs.ATG" 
+#line  1752 "cs.ATG" 
 out stmt);
 
-#line  1753 "cs.ATG" 
+#line  1752 "cs.ATG" 
 			catchClause = new CatchClause(stmt);  
 		} else if (la.kind == 20) {
 			lexer.NextToken();
 			ClassType(
-#line  1756 "cs.ATG" 
+#line  1755 "cs.ATG" 
 out typeRef, false);
 
-#line  1756 "cs.ATG" 
+#line  1755 "cs.ATG" 
 			identifier = null; 
 			if (StartOf(18)) {
 				Identifier();
 
-#line  1757 "cs.ATG" 
+#line  1756 "cs.ATG" 
 				identifier = t.val; 
 			}
 			Expect(21);
 			Block(
-#line  1758 "cs.ATG" 
+#line  1757 "cs.ATG" 
 out stmt);
 
-#line  1759 "cs.ATG" 
+#line  1758 "cs.ATG" 
 			catchClause = new CatchClause(typeRef, identifier, stmt); 
 		} else SynErr(204);
 
-#line  1762 "cs.ATG" 
+#line  1761 "cs.ATG" 
 		if (catchClause != null) {
 		catchClause.StartLocation = startPos;
 		catchClause.EndLocation = t.Location;
@@ -4238,75 +4231,75 @@ out stmt);
 	}
 
 	void UnaryExpr(
-#line  1831 "cs.ATG" 
+#line  1830 "cs.ATG" 
 out Expression uExpr) {
 
-#line  1833 "cs.ATG" 
+#line  1832 "cs.ATG" 
 		TypeReference type = null;
 		Expression expr = null;
 		ArrayList expressions = new ArrayList();
 		uExpr = null;
 		
-		while (StartOf(32) || 
-#line  1855 "cs.ATG" 
+		while (StartOf(33) || 
+#line  1854 "cs.ATG" 
 IsTypeCast()) {
 			if (la.kind == 4) {
 				lexer.NextToken();
 
-#line  1842 "cs.ATG" 
+#line  1841 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.Plus) { StartLocation = t.Location }); 
 			} else if (la.kind == 5) {
 				lexer.NextToken();
 
-#line  1843 "cs.ATG" 
+#line  1842 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.Minus) { StartLocation = t.Location }); 
 			} else if (la.kind == 24) {
 				lexer.NextToken();
 
-#line  1844 "cs.ATG" 
+#line  1843 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.Not) { StartLocation = t.Location }); 
 			} else if (la.kind == 27) {
 				lexer.NextToken();
 
-#line  1845 "cs.ATG" 
+#line  1844 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.BitNot) { StartLocation = t.Location }); 
 			} else if (la.kind == 6) {
 				lexer.NextToken();
 
-#line  1846 "cs.ATG" 
+#line  1845 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.Dereference) { StartLocation = t.Location }); 
 			} else if (la.kind == 31) {
 				lexer.NextToken();
 
-#line  1847 "cs.ATG" 
+#line  1846 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.Increment) { StartLocation = t.Location }); 
 			} else if (la.kind == 32) {
 				lexer.NextToken();
 
-#line  1848 "cs.ATG" 
+#line  1847 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.Decrement) { StartLocation = t.Location }); 
 			} else if (la.kind == 28) {
 				lexer.NextToken();
 
-#line  1849 "cs.ATG" 
+#line  1848 "cs.ATG" 
 				expressions.Add(new UnaryOperatorExpression(UnaryOperatorType.AddressOf) { StartLocation = t.Location }); 
 			} else {
 				Expect(20);
 				Type(
-#line  1855 "cs.ATG" 
+#line  1854 "cs.ATG" 
 out type);
 				Expect(21);
 
-#line  1855 "cs.ATG" 
+#line  1854 "cs.ATG" 
 				expressions.Add(new CastExpression(type) { StartLocation = t.Location }); 
 			}
 		}
 		if (
-#line  1860 "cs.ATG" 
+#line  1859 "cs.ATG" 
 LastExpressionIsUnaryMinus(expressions) && IsMostNegativeIntegerWithoutTypeSuffix()) {
 			Expect(2);
 
-#line  1863 "cs.ATG" 
+#line  1862 "cs.ATG" 
 			expressions.RemoveAt(expressions.Count - 1);
 			if (t.literalValue is uint) {
 				expr = new PrimitiveExpression(int.MinValue, int.MinValue.ToString());
@@ -4316,13 +4309,13 @@ LastExpressionIsUnaryMinus(expressions) && IsMostNegativeIntegerWithoutTypeSuffi
 				throw new Exception("t.literalValue must be uint or ulong");
 			}
 			
-		} else if (StartOf(33)) {
+		} else if (StartOf(34)) {
 			PrimaryExpr(
-#line  1872 "cs.ATG" 
+#line  1871 "cs.ATG" 
 out expr);
 		} else SynErr(205);
 
-#line  1874 "cs.ATG" 
+#line  1873 "cs.ATG" 
 		for (int i = 0; i < expressions.Count; ++i) {
 		Expression nextExpression = i + 1 < expressions.Count ? (Expression)expressions[i + 1] : expr;
 		if (expressions[i] is CastExpression) {
@@ -4340,325 +4333,325 @@ out expr);
 	}
 
 	void ConditionalOrExpr(
-#line  2184 "cs.ATG" 
+#line  2183 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2185 "cs.ATG" 
+#line  2184 "cs.ATG" 
 		Expression expr; Location startLocation = la.Location; 
 		ConditionalAndExpr(
-#line  2187 "cs.ATG" 
+#line  2186 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 26) {
 			lexer.NextToken();
 			UnaryExpr(
-#line  2187 "cs.ATG" 
+#line  2186 "cs.ATG" 
 out expr);
 			ConditionalAndExpr(
-#line  2187 "cs.ATG" 
+#line  2186 "cs.ATG" 
 ref expr);
 
-#line  2187 "cs.ATG" 
+#line  2186 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, BinaryOperatorType.LogicalOr, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void PrimaryExpr(
-#line  1891 "cs.ATG" 
+#line  1890 "cs.ATG" 
 out Expression pexpr) {
 
-#line  1893 "cs.ATG" 
+#line  1892 "cs.ATG" 
 		TypeReference type = null;
 		Expression expr;
 		pexpr = null;
 		
 
-#line  1898 "cs.ATG" 
+#line  1897 "cs.ATG" 
 		Location startLocation = la.Location; 
 		if (la.kind == 113) {
 			lexer.NextToken();
 
-#line  1900 "cs.ATG" 
+#line  1899 "cs.ATG" 
 			pexpr = new PrimitiveExpression(true, "true");  
 		} else if (la.kind == 72) {
 			lexer.NextToken();
 
-#line  1901 "cs.ATG" 
+#line  1900 "cs.ATG" 
 			pexpr = new PrimitiveExpression(false, "false"); 
 		} else if (la.kind == 90) {
 			lexer.NextToken();
 
-#line  1902 "cs.ATG" 
+#line  1901 "cs.ATG" 
 			pexpr = new PrimitiveExpression(null, "null");  
 		} else if (la.kind == 2) {
 			lexer.NextToken();
 
-#line  1903 "cs.ATG" 
+#line  1902 "cs.ATG" 
 			pexpr = new PrimitiveExpression(t.literalValue, t.val) { LiteralFormat = t.literalFormat };  
 		} else if (
-#line  1904 "cs.ATG" 
+#line  1903 "cs.ATG" 
 StartOfQueryExpression()) {
 			QueryExpression(
-#line  1905 "cs.ATG" 
+#line  1904 "cs.ATG" 
 out pexpr);
 		} else if (
-#line  1906 "cs.ATG" 
+#line  1905 "cs.ATG" 
 IdentAndDoubleColon()) {
 			Identifier();
 
-#line  1907 "cs.ATG" 
+#line  1906 "cs.ATG" 
 			type = new TypeReference(t.val); 
 			Expect(10);
 
-#line  1908 "cs.ATG" 
+#line  1907 "cs.ATG" 
 			pexpr = new TypeReferenceExpression(type); 
 			Identifier();
 
-#line  1909 "cs.ATG" 
+#line  1908 "cs.ATG" 
 			if (type.Type == "global") { type.IsGlobal = true; type.Type = t.val ?? "?"; } else type.Type += "." + (t.val ?? "?"); 
 		} else if (StartOf(18)) {
 			Identifier();
 
-#line  1913 "cs.ATG" 
+#line  1912 "cs.ATG" 
 			pexpr = new IdentifierExpression(t.val); 
 			if (la.kind == 48 || 
-#line  1916 "cs.ATG" 
+#line  1915 "cs.ATG" 
 IsGenericInSimpleNameOrMemberAccess()) {
 				if (la.kind == 48) {
 					ShortedLambdaExpression(
-#line  1915 "cs.ATG" 
+#line  1914 "cs.ATG" 
 (IdentifierExpression)pexpr, out pexpr);
 				} else {
 
-#line  1917 "cs.ATG" 
+#line  1916 "cs.ATG" 
 					List<TypeReference> typeList; 
 					TypeArgumentList(
-#line  1918 "cs.ATG" 
+#line  1917 "cs.ATG" 
 out typeList, false);
 
-#line  1919 "cs.ATG" 
+#line  1918 "cs.ATG" 
 					((IdentifierExpression)pexpr).TypeArguments = typeList; 
 				}
 			}
 		} else if (
-#line  1921 "cs.ATG" 
+#line  1920 "cs.ATG" 
 IsLambdaExpression()) {
 			LambdaExpression(
-#line  1922 "cs.ATG" 
+#line  1921 "cs.ATG" 
 out pexpr);
 		} else if (la.kind == 20) {
 			lexer.NextToken();
 			Expr(
-#line  1925 "cs.ATG" 
+#line  1924 "cs.ATG" 
 out expr);
 			Expect(21);
 
-#line  1925 "cs.ATG" 
+#line  1924 "cs.ATG" 
 			pexpr = new ParenthesizedExpression(expr); 
-		} else if (StartOf(34)) {
+		} else if (StartOf(35)) {
 
-#line  1928 "cs.ATG" 
+#line  1927 "cs.ATG" 
 			string val = null; 
 			switch (la.kind) {
 			case 52: {
 				lexer.NextToken();
 
-#line  1929 "cs.ATG" 
+#line  1928 "cs.ATG" 
 				val = "System.Boolean"; 
 				break;
 			}
 			case 54: {
 				lexer.NextToken();
 
-#line  1930 "cs.ATG" 
+#line  1929 "cs.ATG" 
 				val = "System.Byte"; 
 				break;
 			}
 			case 57: {
 				lexer.NextToken();
 
-#line  1931 "cs.ATG" 
+#line  1930 "cs.ATG" 
 				val = "System.Char"; 
 				break;
 			}
 			case 62: {
 				lexer.NextToken();
 
-#line  1932 "cs.ATG" 
+#line  1931 "cs.ATG" 
 				val = "System.Decimal"; 
 				break;
 			}
 			case 66: {
 				lexer.NextToken();
 
-#line  1933 "cs.ATG" 
+#line  1932 "cs.ATG" 
 				val = "System.Double"; 
 				break;
 			}
 			case 75: {
 				lexer.NextToken();
 
-#line  1934 "cs.ATG" 
+#line  1933 "cs.ATG" 
 				val = "System.Single"; 
 				break;
 			}
 			case 82: {
 				lexer.NextToken();
 
-#line  1935 "cs.ATG" 
+#line  1934 "cs.ATG" 
 				val = "System.Int32"; 
 				break;
 			}
 			case 87: {
 				lexer.NextToken();
 
-#line  1936 "cs.ATG" 
+#line  1935 "cs.ATG" 
 				val = "System.Int64"; 
 				break;
 			}
 			case 91: {
 				lexer.NextToken();
 
-#line  1937 "cs.ATG" 
+#line  1936 "cs.ATG" 
 				val = "System.Object"; 
 				break;
 			}
 			case 102: {
 				lexer.NextToken();
 
-#line  1938 "cs.ATG" 
+#line  1937 "cs.ATG" 
 				val = "System.SByte"; 
 				break;
 			}
 			case 104: {
 				lexer.NextToken();
 
-#line  1939 "cs.ATG" 
+#line  1938 "cs.ATG" 
 				val = "System.Int16"; 
 				break;
 			}
 			case 108: {
 				lexer.NextToken();
 
-#line  1940 "cs.ATG" 
+#line  1939 "cs.ATG" 
 				val = "System.String"; 
 				break;
 			}
 			case 116: {
 				lexer.NextToken();
 
-#line  1941 "cs.ATG" 
+#line  1940 "cs.ATG" 
 				val = "System.UInt32"; 
 				break;
 			}
 			case 117: {
 				lexer.NextToken();
 
-#line  1942 "cs.ATG" 
+#line  1941 "cs.ATG" 
 				val = "System.UInt64"; 
 				break;
 			}
 			case 120: {
 				lexer.NextToken();
 
-#line  1943 "cs.ATG" 
+#line  1942 "cs.ATG" 
 				val = "System.UInt16"; 
 				break;
 			}
 			case 123: {
 				lexer.NextToken();
 
-#line  1944 "cs.ATG" 
+#line  1943 "cs.ATG" 
 				val = "System.Void"; 
 				break;
 			}
 			}
 
-#line  1946 "cs.ATG" 
+#line  1945 "cs.ATG" 
 			pexpr = new TypeReferenceExpression(new TypeReference(val, true)) { StartLocation = t.Location, EndLocation = t.EndLocation }; 
 		} else if (la.kind == 111) {
 			lexer.NextToken();
 
-#line  1949 "cs.ATG" 
+#line  1948 "cs.ATG" 
 			pexpr = new ThisReferenceExpression(); pexpr.StartLocation = t.Location; pexpr.EndLocation = t.EndLocation; 
 		} else if (la.kind == 51) {
 			lexer.NextToken();
 
-#line  1951 "cs.ATG" 
+#line  1950 "cs.ATG" 
 			pexpr = new BaseReferenceExpression(); pexpr.StartLocation = t.Location; pexpr.EndLocation = t.EndLocation; 
 		} else if (la.kind == 89) {
 			NewExpression(
-#line  1954 "cs.ATG" 
+#line  1953 "cs.ATG" 
 out pexpr);
 		} else if (la.kind == 115) {
 			lexer.NextToken();
 			Expect(20);
 			if (
-#line  1958 "cs.ATG" 
+#line  1957 "cs.ATG" 
 NotVoidPointer()) {
 				Expect(123);
 
-#line  1958 "cs.ATG" 
+#line  1957 "cs.ATG" 
 				type = new TypeReference("System.Void", true); 
 			} else if (StartOf(10)) {
 				TypeWithRestriction(
-#line  1959 "cs.ATG" 
+#line  1958 "cs.ATG" 
 out type, true, true);
 			} else SynErr(206);
 			Expect(21);
 
-#line  1961 "cs.ATG" 
+#line  1960 "cs.ATG" 
 			pexpr = new TypeOfExpression(type); 
 		} else if (la.kind == 63) {
 			lexer.NextToken();
 			Expect(20);
 			Type(
-#line  1963 "cs.ATG" 
+#line  1962 "cs.ATG" 
 out type);
 			Expect(21);
 
-#line  1963 "cs.ATG" 
+#line  1962 "cs.ATG" 
 			pexpr = new DefaultValueExpression(type); 
 		} else if (la.kind == 105) {
 			lexer.NextToken();
 			Expect(20);
 			Type(
-#line  1964 "cs.ATG" 
+#line  1963 "cs.ATG" 
 out type);
 			Expect(21);
 
-#line  1964 "cs.ATG" 
+#line  1963 "cs.ATG" 
 			pexpr = new SizeOfExpression(type); 
 		} else if (la.kind == 58) {
 			lexer.NextToken();
 			Expect(20);
 			Expr(
-#line  1965 "cs.ATG" 
+#line  1964 "cs.ATG" 
 out expr);
 			Expect(21);
 
-#line  1965 "cs.ATG" 
+#line  1964 "cs.ATG" 
 			pexpr = new CheckedExpression(expr); 
 		} else if (la.kind == 118) {
 			lexer.NextToken();
 			Expect(20);
 			Expr(
-#line  1966 "cs.ATG" 
+#line  1965 "cs.ATG" 
 out expr);
 			Expect(21);
 
-#line  1966 "cs.ATG" 
+#line  1965 "cs.ATG" 
 			pexpr = new UncheckedExpression(expr); 
 		} else if (la.kind == 64) {
 			lexer.NextToken();
 			AnonymousMethodExpr(
-#line  1967 "cs.ATG" 
+#line  1966 "cs.ATG" 
 out expr);
 
-#line  1967 "cs.ATG" 
+#line  1966 "cs.ATG" 
 			pexpr = expr; 
 		} else SynErr(207);
 
-#line  1969 "cs.ATG" 
+#line  1968 "cs.ATG" 
 		if (pexpr != null) {
 		if (pexpr.StartLocation.IsEmpty)
 			pexpr.StartLocation = startLocation;
@@ -4666,59 +4659,59 @@ out expr);
 			pexpr.EndLocation = t.EndLocation;
 		}
 		
-		while (StartOf(35)) {
+		while (StartOf(36)) {
 
-#line  1977 "cs.ATG" 
+#line  1976 "cs.ATG" 
 			startLocation = la.Location; 
 			switch (la.kind) {
 			case 31: {
 				lexer.NextToken();
 
-#line  1979 "cs.ATG" 
+#line  1978 "cs.ATG" 
 				pexpr = new UnaryOperatorExpression(pexpr, UnaryOperatorType.PostIncrement); 
 				break;
 			}
 			case 32: {
 				lexer.NextToken();
 
-#line  1981 "cs.ATG" 
+#line  1980 "cs.ATG" 
 				pexpr = new UnaryOperatorExpression(pexpr, UnaryOperatorType.PostDecrement); 
 				break;
 			}
 			case 47: {
 				PointerMemberAccess(
-#line  1983 "cs.ATG" 
+#line  1982 "cs.ATG" 
 out pexpr, pexpr);
 				break;
 			}
 			case 15: {
 				MemberAccess(
-#line  1984 "cs.ATG" 
+#line  1983 "cs.ATG" 
 out pexpr, pexpr);
 				break;
 			}
 			case 20: {
 				lexer.NextToken();
 
-#line  1988 "cs.ATG" 
+#line  1987 "cs.ATG" 
 				List<Expression> parameters = new List<Expression>(); 
 
-#line  1989 "cs.ATG" 
+#line  1988 "cs.ATG" 
 				pexpr = new InvocationExpression(pexpr, parameters); 
-				if (StartOf(25)) {
+				if (StartOf(26)) {
 					Argument(
-#line  1990 "cs.ATG" 
+#line  1989 "cs.ATG" 
 out expr);
 
-#line  1990 "cs.ATG" 
+#line  1989 "cs.ATG" 
 					SafeAdd(pexpr, parameters, expr); 
 					while (la.kind == 14) {
 						lexer.NextToken();
 						Argument(
-#line  1991 "cs.ATG" 
+#line  1990 "cs.ATG" 
 out expr);
 
-#line  1991 "cs.ATG" 
+#line  1990 "cs.ATG" 
 						SafeAdd(pexpr, parameters, expr); 
 					}
 				}
@@ -4727,24 +4720,24 @@ out expr);
 			}
 			case 18: {
 
-#line  1997 "cs.ATG" 
+#line  1996 "cs.ATG" 
 				List<Expression> indices = new List<Expression>();
 				pexpr = new IndexerExpression(pexpr, indices);
 				
 				lexer.NextToken();
 				Expr(
-#line  2000 "cs.ATG" 
+#line  1999 "cs.ATG" 
 out expr);
 
-#line  2000 "cs.ATG" 
+#line  1999 "cs.ATG" 
 				SafeAdd(pexpr, indices, expr); 
 				while (la.kind == 14) {
 					lexer.NextToken();
 					Expr(
-#line  2001 "cs.ATG" 
+#line  2000 "cs.ATG" 
 out expr);
 
-#line  2001 "cs.ATG" 
+#line  2000 "cs.ATG" 
 					SafeAdd(pexpr, indices, expr); 
 				}
 				Expect(19);
@@ -4752,7 +4745,7 @@ out expr);
 			}
 			}
 
-#line  2004 "cs.ATG" 
+#line  2003 "cs.ATG" 
 			if (pexpr != null) {
 			if (pexpr.StartLocation.IsEmpty)
 				pexpr.StartLocation = startLocation;
@@ -4764,83 +4757,83 @@ out expr);
 	}
 
 	void QueryExpression(
-#line  2442 "cs.ATG" 
+#line  2441 "cs.ATG" 
 out Expression outExpr) {
 
-#line  2443 "cs.ATG" 
+#line  2442 "cs.ATG" 
 		QueryExpression q = new QueryExpression(); outExpr = q; q.StartLocation = la.Location; 
 		QueryExpressionFromClause fromClause;
 		
 		QueryExpressionFromClause(
-#line  2447 "cs.ATG" 
+#line  2446 "cs.ATG" 
 out fromClause);
 
-#line  2447 "cs.ATG" 
+#line  2446 "cs.ATG" 
 		q.FromClause = fromClause; 
 		QueryExpressionBody(
-#line  2448 "cs.ATG" 
+#line  2447 "cs.ATG" 
 ref q);
 
-#line  2449 "cs.ATG" 
+#line  2448 "cs.ATG" 
 		q.EndLocation = t.EndLocation; 
 		outExpr = q; /* set outExpr to q again if QueryExpressionBody changed it (can happen with 'into' clauses) */ 
 		
 	}
 
 	void ShortedLambdaExpression(
-#line  2118 "cs.ATG" 
+#line  2117 "cs.ATG" 
 IdentifierExpression ident, out Expression pexpr) {
 
-#line  2119 "cs.ATG" 
+#line  2118 "cs.ATG" 
 		LambdaExpression lambda = new LambdaExpression(); pexpr = lambda; 
 		Expect(48);
 
-#line  2124 "cs.ATG" 
+#line  2123 "cs.ATG" 
 		lambda.StartLocation = ident.StartLocation;
 		SafeAdd(lambda, lambda.Parameters, new ParameterDeclarationExpression(null, ident.Identifier));
 		lambda.Parameters[0].StartLocation = ident.StartLocation;
 		lambda.Parameters[0].EndLocation = ident.EndLocation;
 		
 		LambdaExpressionBody(
-#line  2129 "cs.ATG" 
+#line  2128 "cs.ATG" 
 lambda);
 	}
 
 	void TypeArgumentList(
-#line  2361 "cs.ATG" 
+#line  2360 "cs.ATG" 
 out List<TypeReference> types, bool canBeUnbound) {
 
-#line  2363 "cs.ATG" 
+#line  2362 "cs.ATG" 
 		types = new List<TypeReference>();
 		TypeReference type = null;
 		
 		Expect(23);
 		if (
-#line  2368 "cs.ATG" 
+#line  2367 "cs.ATG" 
 canBeUnbound && (la.kind == Tokens.GreaterThan || la.kind == Tokens.Comma)) {
 
-#line  2369 "cs.ATG" 
+#line  2368 "cs.ATG" 
 			types.Add(TypeReference.Null); 
 			while (la.kind == 14) {
 				lexer.NextToken();
 
-#line  2370 "cs.ATG" 
+#line  2369 "cs.ATG" 
 				types.Add(TypeReference.Null); 
 			}
 		} else if (StartOf(10)) {
 			Type(
-#line  2371 "cs.ATG" 
+#line  2370 "cs.ATG" 
 out type);
 
-#line  2371 "cs.ATG" 
+#line  2370 "cs.ATG" 
 			if (type != null) { types.Add(type); } 
 			while (la.kind == 14) {
 				lexer.NextToken();
 				Type(
-#line  2372 "cs.ATG" 
+#line  2371 "cs.ATG" 
 out type);
 
-#line  2372 "cs.ATG" 
+#line  2371 "cs.ATG" 
 				if (type != null) { types.Add(type); } 
 			}
 		} else SynErr(208);
@@ -4848,45 +4841,45 @@ out type);
 	}
 
 	void LambdaExpression(
-#line  2098 "cs.ATG" 
+#line  2097 "cs.ATG" 
 out Expression outExpr) {
 
-#line  2100 "cs.ATG" 
+#line  2099 "cs.ATG" 
 		LambdaExpression lambda = new LambdaExpression();
 		lambda.StartLocation = la.Location;
 		ParameterDeclarationExpression p;
 		outExpr = lambda;
 		
 		Expect(20);
-		if (StartOf(36)) {
+		if (StartOf(37)) {
 			LambdaExpressionParameter(
-#line  2108 "cs.ATG" 
+#line  2107 "cs.ATG" 
 out p);
 
-#line  2108 "cs.ATG" 
+#line  2107 "cs.ATG" 
 			SafeAdd(lambda, lambda.Parameters, p); 
 			while (la.kind == 14) {
 				lexer.NextToken();
 				LambdaExpressionParameter(
-#line  2110 "cs.ATG" 
+#line  2109 "cs.ATG" 
 out p);
 
-#line  2110 "cs.ATG" 
+#line  2109 "cs.ATG" 
 				SafeAdd(lambda, lambda.Parameters, p); 
 			}
 		}
 		Expect(21);
 		Expect(48);
 		LambdaExpressionBody(
-#line  2115 "cs.ATG" 
+#line  2114 "cs.ATG" 
 lambda);
 	}
 
 	void NewExpression(
-#line  2045 "cs.ATG" 
+#line  2044 "cs.ATG" 
 out Expression pexpr) {
 
-#line  2046 "cs.ATG" 
+#line  2045 "cs.ATG" 
 		pexpr = null;
 		List<Expression> parameters = new List<Expression>();
 		TypeReference type = null;
@@ -4895,65 +4888,65 @@ out Expression pexpr) {
 		Expect(89);
 		if (StartOf(10)) {
 			NonArrayType(
-#line  2053 "cs.ATG" 
+#line  2052 "cs.ATG" 
 out type);
 		}
 		if (la.kind == 16 || la.kind == 20) {
 			if (la.kind == 20) {
 
-#line  2059 "cs.ATG" 
+#line  2058 "cs.ATG" 
 				ObjectCreateExpression oce = new ObjectCreateExpression(type, parameters); 
 				lexer.NextToken();
 
-#line  2060 "cs.ATG" 
+#line  2059 "cs.ATG" 
 				if (type == null) Error("Cannot use an anonymous type with arguments for the constructor"); 
-				if (StartOf(25)) {
+				if (StartOf(26)) {
 					Argument(
-#line  2061 "cs.ATG" 
+#line  2060 "cs.ATG" 
 out expr);
 
-#line  2061 "cs.ATG" 
+#line  2060 "cs.ATG" 
 					SafeAdd(oce, parameters, expr); 
 					while (la.kind == 14) {
 						lexer.NextToken();
 						Argument(
-#line  2062 "cs.ATG" 
+#line  2061 "cs.ATG" 
 out expr);
 
-#line  2062 "cs.ATG" 
+#line  2061 "cs.ATG" 
 						SafeAdd(oce, parameters, expr); 
 					}
 				}
 				Expect(21);
 
-#line  2064 "cs.ATG" 
+#line  2063 "cs.ATG" 
 				pexpr = oce; 
 				if (la.kind == 16) {
 					CollectionOrObjectInitializer(
-#line  2065 "cs.ATG" 
+#line  2064 "cs.ATG" 
 out expr);
 
-#line  2065 "cs.ATG" 
+#line  2064 "cs.ATG" 
 					oce.ObjectInitializer = (CollectionInitializerExpression)expr; 
 				}
 			} else {
 
-#line  2066 "cs.ATG" 
+#line  2065 "cs.ATG" 
 				ObjectCreateExpression oce = new ObjectCreateExpression(type, parameters); 
 				CollectionOrObjectInitializer(
-#line  2067 "cs.ATG" 
+#line  2066 "cs.ATG" 
 out expr);
 
-#line  2067 "cs.ATG" 
+#line  2066 "cs.ATG" 
 				oce.ObjectInitializer = (CollectionInitializerExpression)expr; 
 
-#line  2068 "cs.ATG" 
+#line  2067 "cs.ATG" 
 				pexpr = oce; 
 			}
 		} else if (la.kind == 18) {
 			lexer.NextToken();
 
-#line  2073 "cs.ATG" 
+#line  2072 "cs.ATG" 
 			ArrayCreateExpression ace = new ArrayCreateExpression(type);
 			/* we must not change RankSpecifier on the null type reference*/
 			if (ace.CreateType.IsNull) { ace.CreateType = new TypeReference(""); }
@@ -4964,80 +4957,80 @@ out expr);
 				while (la.kind == 14) {
 					lexer.NextToken();
 
-#line  2080 "cs.ATG" 
+#line  2079 "cs.ATG" 
 					dims += 1; 
 				}
 				Expect(19);
 
-#line  2081 "cs.ATG" 
+#line  2080 "cs.ATG" 
 				ranks.Add(dims); dims = 0; 
 				while (la.kind == 18) {
 					lexer.NextToken();
 					while (la.kind == 14) {
 						lexer.NextToken();
 
-#line  2082 "cs.ATG" 
+#line  2081 "cs.ATG" 
 						++dims; 
 					}
 					Expect(19);
 
-#line  2082 "cs.ATG" 
+#line  2081 "cs.ATG" 
 					ranks.Add(dims); dims = 0; 
 				}
 
-#line  2083 "cs.ATG" 
+#line  2082 "cs.ATG" 
 				ace.CreateType.RankSpecifier = ranks.ToArray(); 
 				CollectionInitializer(
-#line  2084 "cs.ATG" 
+#line  2083 "cs.ATG" 
 out expr);
 
-#line  2084 "cs.ATG" 
+#line  2083 "cs.ATG" 
 				ace.ArrayInitializer = (CollectionInitializerExpression)expr; 
 			} else if (StartOf(6)) {
 				Expr(
-#line  2085 "cs.ATG" 
+#line  2084 "cs.ATG" 
 out expr);
 
-#line  2085 "cs.ATG" 
+#line  2084 "cs.ATG" 
 				if (expr != null) parameters.Add(expr); 
 				while (la.kind == 14) {
 					lexer.NextToken();
 
-#line  2086 "cs.ATG" 
+#line  2085 "cs.ATG" 
 					dims += 1; 
 					Expr(
-#line  2087 "cs.ATG" 
+#line  2086 "cs.ATG" 
 out expr);
 
-#line  2087 "cs.ATG" 
+#line  2086 "cs.ATG" 
 					if (expr != null) parameters.Add(expr); 
 				}
 				Expect(19);
 
-#line  2089 "cs.ATG" 
+#line  2088 "cs.ATG" 
 				ranks.Add(dims); ace.Arguments = parameters; dims = 0; 
 				while (la.kind == 18) {
 					lexer.NextToken();
 					while (la.kind == 14) {
 						lexer.NextToken();
 
-#line  2090 "cs.ATG" 
+#line  2089 "cs.ATG" 
 						++dims; 
 					}
 					Expect(19);
 
-#line  2090 "cs.ATG" 
+#line  2089 "cs.ATG" 
 					ranks.Add(dims); dims = 0; 
 				}
 
-#line  2091 "cs.ATG" 
+#line  2090 "cs.ATG" 
 				ace.CreateType.RankSpecifier = ranks.ToArray(); 
 				if (la.kind == 16) {
 					CollectionInitializer(
-#line  2092 "cs.ATG" 
+#line  2091 "cs.ATG" 
 out expr);
 
-#line  2092 "cs.ATG" 
+#line  2091 "cs.ATG" 
 					ace.ArrayInitializer = (CollectionInitializerExpression)expr; 
 				}
 			} else SynErr(209);
@@ -5045,10 +5038,10 @@ out expr);
 	}
 
 	void AnonymousMethodExpr(
-#line  2165 "cs.ATG" 
+#line  2164 "cs.ATG" 
 out Expression outExpr) {
 
-#line  2167 "cs.ATG" 
+#line  2166 "cs.ATG" 
 		AnonymousMethodExpression expr = new AnonymousMethodExpression();
 		expr.StartLocation = t.Location;
 		BlockStatement stmt;
@@ -5059,59 +5052,59 @@ out Expression outExpr) {
 			lexer.NextToken();
 			if (StartOf(11)) {
 				FormalParameterList(
-#line  2176 "cs.ATG" 
+#line  2175 "cs.ATG" 
 p);
 
-#line  2176 "cs.ATG" 
+#line  2175 "cs.ATG" 
 				expr.Parameters = p; 
 			}
 			Expect(21);
 
-#line  2178 "cs.ATG" 
+#line  2177 "cs.ATG" 
 			expr.HasParameterList = true; 
 		}
 		Block(
-#line  2180 "cs.ATG" 
+#line  2179 "cs.ATG" 
 out stmt);
 
-#line  2180 "cs.ATG" 
+#line  2179 "cs.ATG" 
 		expr.Body = stmt; 
 
-#line  2181 "cs.ATG" 
+#line  2180 "cs.ATG" 
 		expr.EndLocation = t.Location; 
 	}
 
 	void PointerMemberAccess(
-#line  2033 "cs.ATG" 
+#line  2032 "cs.ATG" 
 out Expression expr, Expression target) {
 
-#line  2034 "cs.ATG" 
+#line  2033 "cs.ATG" 
 		List<TypeReference> typeList; 
 		Expect(47);
 		Identifier();
 
-#line  2038 "cs.ATG" 
+#line  2037 "cs.ATG" 
 		expr = new PointerReferenceExpression(target, t.val); expr.StartLocation = t.Location; expr.EndLocation = t.EndLocation; 
 		if (
-#line  2039 "cs.ATG" 
+#line  2038 "cs.ATG" 
 IsGenericInSimpleNameOrMemberAccess()) {
 			TypeArgumentList(
-#line  2040 "cs.ATG" 
+#line  2039 "cs.ATG" 
 out typeList, false);
 
-#line  2041 "cs.ATG" 
+#line  2040 "cs.ATG" 
 			((MemberReferenceExpression)expr).TypeArguments = typeList; 
 		}
 	}
 
 	void MemberAccess(
-#line  2014 "cs.ATG" 
+#line  2013 "cs.ATG" 
 out Expression expr, Expression target) {
 
-#line  2015 "cs.ATG" 
+#line  2014 "cs.ATG" 
 		List<TypeReference> typeList; 
 
-#line  2017 "cs.ATG" 
+#line  2016 "cs.ATG" 
 		if (ShouldConvertTargetExpressionToTypeReference(target)) {
 		TypeReference type = GetTypeReferenceFromExpression(target);
 		if (type != null) {
@@ -5121,62 +5114,62 @@ out Expression expr, Expression target) {
 		
 		Expect(15);
 
-#line  2024 "cs.ATG" 
+#line  2023 "cs.ATG" 
 		Location startLocation = t.Location; 
 		Identifier();
 
-#line  2026 "cs.ATG" 
+#line  2025 "cs.ATG" 
 		expr = new MemberReferenceExpression(target, t.val); expr.StartLocation = startLocation; expr.EndLocation = t.EndLocation; 
 		if (
-#line  2027 "cs.ATG" 
+#line  2026 "cs.ATG" 
 IsGenericInSimpleNameOrMemberAccess()) {
 			TypeArgumentList(
-#line  2028 "cs.ATG" 
+#line  2027 "cs.ATG" 
 out typeList, false);
 
-#line  2029 "cs.ATG" 
+#line  2028 "cs.ATG" 
 			((MemberReferenceExpression)expr).TypeArguments = typeList; 
 		}
 	}
 
 	void LambdaExpressionParameter(
-#line  2132 "cs.ATG" 
+#line  2131 "cs.ATG" 
 out ParameterDeclarationExpression p) {
 
-#line  2133 "cs.ATG" 
+#line  2132 "cs.ATG" 
 		Location start = la.Location; p = null;
 		TypeReference type;
 		ParameterModifiers mod = ParameterModifiers.In;
 		
 		if (
-#line  2138 "cs.ATG" 
+#line  2137 "cs.ATG" 
 Peek(1).kind == Tokens.Comma || Peek(1).kind == Tokens.CloseParenthesis) {
 			Identifier();
 
-#line  2140 "cs.ATG" 
+#line  2139 "cs.ATG" 
 			p = new ParameterDeclarationExpression(null, t.val);
 			p.StartLocation = start; p.EndLocation = t.EndLocation;
 			
-		} else if (StartOf(36)) {
+		} else if (StartOf(37)) {
 			if (la.kind == 93 || la.kind == 100) {
 				if (la.kind == 100) {
 					lexer.NextToken();
 
-#line  2143 "cs.ATG" 
+#line  2142 "cs.ATG" 
 					mod = ParameterModifiers.Ref; 
 				} else {
 					lexer.NextToken();
 
-#line  2144 "cs.ATG" 
+#line  2143 "cs.ATG" 
 					mod = ParameterModifiers.Out; 
 				}
 			}
 			Type(
-#line  2146 "cs.ATG" 
+#line  2145 "cs.ATG" 
 out type);
 			Identifier();
 
-#line  2148 "cs.ATG" 
+#line  2147 "cs.ATG" 
 			p = new ParameterDeclarationExpression(type, t.val, mod);
 			p.StartLocation = start; p.EndLocation = t.EndLocation;
 			
@@ -5184,237 +5177,237 @@ out type);
 	}
 
 	void LambdaExpressionBody(
-#line  2154 "cs.ATG" 
+#line  2153 "cs.ATG" 
 LambdaExpression lambda) {
 
-#line  2155 "cs.ATG" 
+#line  2154 "cs.ATG" 
 		Expression expr; BlockStatement stmt; 
 		if (la.kind == 16) {
 			Block(
-#line  2158 "cs.ATG" 
+#line  2157 "cs.ATG" 
 out stmt);
 
-#line  2158 "cs.ATG" 
+#line  2157 "cs.ATG" 
 			lambda.StatementBody = stmt; 
 		} else if (StartOf(6)) {
 			Expr(
-#line  2159 "cs.ATG" 
+#line  2158 "cs.ATG" 
 out expr);
 
-#line  2159 "cs.ATG" 
+#line  2158 "cs.ATG" 
 			lambda.ExpressionBody = expr; 
 		} else SynErr(212);
 
-#line  2161 "cs.ATG" 
+#line  2160 "cs.ATG" 
 		lambda.EndLocation = t.EndLocation; 
 
-#line  2162 "cs.ATG" 
+#line  2161 "cs.ATG" 
 		lambda.ExtendedEndLocation = la.Location; 
 	}
 
 	void ConditionalAndExpr(
-#line  2190 "cs.ATG" 
+#line  2189 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2191 "cs.ATG" 
+#line  2190 "cs.ATG" 
 		Expression expr; Location startLocation = la.Location; 
 		InclusiveOrExpr(
-#line  2193 "cs.ATG" 
+#line  2192 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 25) {
 			lexer.NextToken();
 			UnaryExpr(
-#line  2193 "cs.ATG" 
+#line  2192 "cs.ATG" 
 out expr);
 			InclusiveOrExpr(
-#line  2193 "cs.ATG" 
+#line  2192 "cs.ATG" 
 ref expr);
 
-#line  2193 "cs.ATG" 
+#line  2192 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, BinaryOperatorType.LogicalAnd, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void InclusiveOrExpr(
-#line  2196 "cs.ATG" 
+#line  2195 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2197 "cs.ATG" 
+#line  2196 "cs.ATG" 
 		Expression expr; Location startLocation = la.Location; 
 		ExclusiveOrExpr(
-#line  2199 "cs.ATG" 
+#line  2198 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 29) {
 			lexer.NextToken();
 			UnaryExpr(
-#line  2199 "cs.ATG" 
+#line  2198 "cs.ATG" 
 out expr);
 			ExclusiveOrExpr(
-#line  2199 "cs.ATG" 
+#line  2198 "cs.ATG" 
 ref expr);
 
-#line  2199 "cs.ATG" 
+#line  2198 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, BinaryOperatorType.BitwiseOr, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void ExclusiveOrExpr(
-#line  2202 "cs.ATG" 
+#line  2201 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2203 "cs.ATG" 
+#line  2202 "cs.ATG" 
 		Expression expr; Location startLocation = la.Location; 
 		AndExpr(
-#line  2205 "cs.ATG" 
+#line  2204 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 30) {
 			lexer.NextToken();
 			UnaryExpr(
-#line  2205 "cs.ATG" 
+#line  2204 "cs.ATG" 
 out expr);
 			AndExpr(
-#line  2205 "cs.ATG" 
+#line  2204 "cs.ATG" 
 ref expr);
 
-#line  2205 "cs.ATG" 
+#line  2204 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, BinaryOperatorType.ExclusiveOr, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void AndExpr(
-#line  2208 "cs.ATG" 
+#line  2207 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2209 "cs.ATG" 
+#line  2208 "cs.ATG" 
 		Expression expr; Location startLocation = la.Location; 
 		EqualityExpr(
-#line  2211 "cs.ATG" 
+#line  2210 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 28) {
 			lexer.NextToken();
 			UnaryExpr(
-#line  2211 "cs.ATG" 
+#line  2210 "cs.ATG" 
 out expr);
 			EqualityExpr(
-#line  2211 "cs.ATG" 
+#line  2210 "cs.ATG" 
 ref expr);
 
-#line  2211 "cs.ATG" 
+#line  2210 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, BinaryOperatorType.BitwiseAnd, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void EqualityExpr(
-#line  2214 "cs.ATG" 
+#line  2213 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2216 "cs.ATG" 
+#line  2215 "cs.ATG" 
 		Expression expr;
 		BinaryOperatorType op = BinaryOperatorType.None;
 		Location startLocation = la.Location;
 		
 		RelationalExpr(
-#line  2221 "cs.ATG" 
+#line  2220 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 33 || la.kind == 34) {
 			if (la.kind == 34) {
 				lexer.NextToken();
 
-#line  2224 "cs.ATG" 
+#line  2223 "cs.ATG" 
 				op = BinaryOperatorType.InEquality; 
 			} else {
 				lexer.NextToken();
 
-#line  2225 "cs.ATG" 
+#line  2224 "cs.ATG" 
 				op = BinaryOperatorType.Equality; 
 			}
 			UnaryExpr(
-#line  2227 "cs.ATG" 
+#line  2226 "cs.ATG" 
 out expr);
 			RelationalExpr(
-#line  2227 "cs.ATG" 
+#line  2226 "cs.ATG" 
 ref expr);
 
-#line  2227 "cs.ATG" 
+#line  2226 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, op, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void RelationalExpr(
-#line  2231 "cs.ATG" 
+#line  2230 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2233 "cs.ATG" 
+#line  2232 "cs.ATG" 
 		TypeReference type;
 		Expression expr;
 		BinaryOperatorType op = BinaryOperatorType.None;
 		Location startLocation = la.Location;
 		
 		ShiftExpr(
-#line  2239 "cs.ATG" 
+#line  2238 "cs.ATG" 
 ref outExpr);
-		while (StartOf(37)) {
-			if (StartOf(38)) {
+		while (StartOf(38)) {
+			if (StartOf(39)) {
 				if (la.kind == 23) {
 					lexer.NextToken();
 
-#line  2241 "cs.ATG" 
+#line  2240 "cs.ATG" 
 					op = BinaryOperatorType.LessThan; 
 				} else if (la.kind == 22) {
 					lexer.NextToken();
 
-#line  2242 "cs.ATG" 
+#line  2241 "cs.ATG" 
 					op = BinaryOperatorType.GreaterThan; 
 				} else if (la.kind == 36) {
 					lexer.NextToken();
 
-#line  2243 "cs.ATG" 
+#line  2242 "cs.ATG" 
 					op = BinaryOperatorType.LessThanOrEqual; 
 				} else if (la.kind == 35) {
 					lexer.NextToken();
 
-#line  2244 "cs.ATG" 
+#line  2243 "cs.ATG" 
 					op = BinaryOperatorType.GreaterThanOrEqual; 
 				} else SynErr(213);
 				UnaryExpr(
-#line  2246 "cs.ATG" 
+#line  2245 "cs.ATG" 
 out expr);
 				ShiftExpr(
-#line  2247 "cs.ATG" 
+#line  2246 "cs.ATG" 
 ref expr);
 
-#line  2248 "cs.ATG" 
+#line  2247 "cs.ATG" 
 				outExpr = new BinaryOperatorExpression(outExpr, op, expr) { StartLocation = startLocation, EndLocation = t.EndLocation }; 
 			} else {
 				if (la.kind == 85) {
 					lexer.NextToken();
 					TypeWithRestriction(
-#line  2251 "cs.ATG" 
+#line  2250 "cs.ATG" 
 out type, false, false);
 					if (
-#line  2252 "cs.ATG" 
+#line  2251 "cs.ATG" 
 la.kind == Tokens.Question && !IsPossibleExpressionStart(Peek(1).kind)) {
 						NullableQuestionMark(
-#line  2253 "cs.ATG" 
+#line  2252 "cs.ATG" 
 ref type);
 					}
 
-#line  2254 "cs.ATG" 
+#line  2253 "cs.ATG" 
 					outExpr = new TypeOfIsExpression(outExpr, type)  { StartLocation = startLocation, EndLocation = t.EndLocation }; 
 				} else if (la.kind == 50) {
 					lexer.NextToken();
 					TypeWithRestriction(
-#line  2256 "cs.ATG" 
+#line  2255 "cs.ATG" 
 out type, false, false);
 					if (
-#line  2257 "cs.ATG" 
+#line  2256 "cs.ATG" 
 la.kind == Tokens.Question && !IsPossibleExpressionStart(Peek(1).kind)) {
 						NullableQuestionMark(
-#line  2258 "cs.ATG" 
+#line  2257 "cs.ATG" 
 ref type);
 					}
 
-#line  2259 "cs.ATG" 
+#line  2258 "cs.ATG" 
 					outExpr = new CastExpression(type, outExpr, CastType.TryCast) { StartLocation = startLocation, EndLocation = t.EndLocation }; 
 				} else SynErr(214);
 			}
@@ -5422,85 +5415,85 @@ ref type);
 	}
 
 	void ShiftExpr(
-#line  2264 "cs.ATG" 
+#line  2263 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2266 "cs.ATG" 
+#line  2265 "cs.ATG" 
 		Expression expr;
 		BinaryOperatorType op = BinaryOperatorType.None;
 		Location startLocation = la.Location;
 		
 		AdditiveExpr(
-#line  2271 "cs.ATG" 
+#line  2270 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 37 || 
-#line  2274 "cs.ATG" 
+#line  2273 "cs.ATG" 
 IsShiftRight()) {
 			if (la.kind == 37) {
 				lexer.NextToken();
 
-#line  2273 "cs.ATG" 
+#line  2272 "cs.ATG" 
 				op = BinaryOperatorType.ShiftLeft; 
 			} else {
 				Expect(22);
 				Expect(22);
 
-#line  2275 "cs.ATG" 
+#line  2274 "cs.ATG" 
 				op = BinaryOperatorType.ShiftRight; 
 			}
 			UnaryExpr(
-#line  2278 "cs.ATG" 
+#line  2277 "cs.ATG" 
 out expr);
 			AdditiveExpr(
-#line  2278 "cs.ATG" 
+#line  2277 "cs.ATG" 
 ref expr);
 
-#line  2278 "cs.ATG" 
+#line  2277 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, op, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void AdditiveExpr(
-#line  2282 "cs.ATG" 
+#line  2281 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2284 "cs.ATG" 
+#line  2283 "cs.ATG" 
 		Expression expr;
 		BinaryOperatorType op = BinaryOperatorType.None;
 		Location startLocation = la.Location;
 		
 		MultiplicativeExpr(
-#line  2289 "cs.ATG" 
+#line  2288 "cs.ATG" 
 ref outExpr);
 		while (la.kind == 4 || la.kind == 5) {
 			if (la.kind == 4) {
 				lexer.NextToken();
 
-#line  2292 "cs.ATG" 
+#line  2291 "cs.ATG" 
 				op = BinaryOperatorType.Add; 
 			} else {
 				lexer.NextToken();
 
-#line  2293 "cs.ATG" 
+#line  2292 "cs.ATG" 
 				op = BinaryOperatorType.Subtract; 
 			}
 			UnaryExpr(
-#line  2295 "cs.ATG" 
+#line  2294 "cs.ATG" 
 out expr);
 			MultiplicativeExpr(
-#line  2295 "cs.ATG" 
+#line  2294 "cs.ATG" 
 ref expr);
 
-#line  2295 "cs.ATG" 
+#line  2294 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, op, expr) { StartLocation = startLocation, EndLocation = t.EndLocation };  
 		}
 	}
 
 	void MultiplicativeExpr(
-#line  2299 "cs.ATG" 
+#line  2298 "cs.ATG" 
 ref Expression outExpr) {
 
-#line  2301 "cs.ATG" 
+#line  2300 "cs.ATG" 
 		Expression expr;
 		BinaryOperatorType op = BinaryOperatorType.None;
 		Location startLocation = la.Location;
@@ -5509,378 +5502,378 @@ ref Expression outExpr) {
 			if (la.kind == 6) {
 				lexer.NextToken();
 
-#line  2308 "cs.ATG" 
+#line  2307 "cs.ATG" 
 				op = BinaryOperatorType.Multiply; 
 			} else if (la.kind == 7) {
 				lexer.NextToken();
 
-#line  2309 "cs.ATG" 
+#line  2308 "cs.ATG" 
 				op = BinaryOperatorType.Divide; 
 			} else {
 				lexer.NextToken();
 
-#line  2310 "cs.ATG" 
+#line  2309 "cs.ATG" 
 				op = BinaryOperatorType.Modulus; 
 			}
 			UnaryExpr(
-#line  2312 "cs.ATG" 
+#line  2311 "cs.ATG" 
 out expr);
 
-#line  2312 "cs.ATG" 
+#line  2311 "cs.ATG" 
 			outExpr = new BinaryOperatorExpression(outExpr, op, expr) { StartLocation = startLocation, EndLocation = t.EndLocation }; 
 		}
 	}
 
 	void VariantTypeParameter(
-#line  2390 "cs.ATG" 
+#line  2389 "cs.ATG" 
 out TemplateDefinition typeParameter) {
 
-#line  2392 "cs.ATG" 
+#line  2391 "cs.ATG" 
 		typeParameter = new TemplateDefinition();
 		AttributeSection section;
 		
 		while (la.kind == 18) {
 			AttributeSection(
-#line  2396 "cs.ATG" 
+#line  2395 "cs.ATG" 
 out section);
 
-#line  2396 "cs.ATG" 
+#line  2395 "cs.ATG" 
 			typeParameter.Attributes.Add(section); 
 		}
 		if (la.kind == 81 || la.kind == 93) {
 			if (la.kind == 81) {
 				lexer.NextToken();
 
-#line  2398 "cs.ATG" 
+#line  2397 "cs.ATG" 
 				typeParameter.VarianceModifier = VarianceModifier.Contravariant; 
 			} else {
 				lexer.NextToken();
 
-#line  2399 "cs.ATG" 
+#line  2398 "cs.ATG" 
 				typeParameter.VarianceModifier = VarianceModifier.Covariant; 
 			}
 		}
 		Identifier();
 
-#line  2401 "cs.ATG" 
+#line  2400 "cs.ATG" 
 		typeParameter.Name = t.val; typeParameter.StartLocation = t.Location; 
 
-#line  2402 "cs.ATG" 
+#line  2401 "cs.ATG" 
 		typeParameter.EndLocation = t.EndLocation; 
 	}
 
 	void TypeParameterConstraintsClauseBase(
-#line  2433 "cs.ATG" 
+#line  2432 "cs.ATG" 
 out TypeReference type) {
 
-#line  2434 "cs.ATG" 
+#line  2433 "cs.ATG" 
 		TypeReference t; type = null; 
 		if (la.kind == 109) {
 			lexer.NextToken();
 
-#line  2436 "cs.ATG" 
+#line  2435 "cs.ATG" 
 			type = TypeReference.StructConstraint; 
 		} else if (la.kind == 59) {
 			lexer.NextToken();
 
-#line  2437 "cs.ATG" 
+#line  2436 "cs.ATG" 
 			type = TypeReference.ClassConstraint; 
 		} else if (la.kind == 89) {
 			lexer.NextToken();
 			Expect(20);
 			Expect(21);
 
-#line  2438 "cs.ATG" 
+#line  2437 "cs.ATG" 
 			type = TypeReference.NewConstraint; 
 		} else if (StartOf(10)) {
 			Type(
-#line  2439 "cs.ATG" 
+#line  2438 "cs.ATG" 
 out t);
 
-#line  2439 "cs.ATG" 
+#line  2438 "cs.ATG" 
 			type = t; 
 		} else SynErr(215);
 	}
 
 	void QueryExpressionFromClause(
-#line  2454 "cs.ATG" 
+#line  2453 "cs.ATG" 
 out QueryExpressionFromClause fc) {
 
-#line  2455 "cs.ATG" 
+#line  2454 "cs.ATG" 
 		fc = new QueryExpressionFromClause();
 		fc.StartLocation = la.Location;
 		CollectionRangeVariable variable;
 		
 		Expect(137);
 		QueryExpressionFromOrJoinClause(
-#line  2461 "cs.ATG" 
+#line  2460 "cs.ATG" 
 out variable);
 
-#line  2462 "cs.ATG" 
+#line  2461 "cs.ATG" 
 		fc.EndLocation = t.EndLocation;
 		fc.Sources.Add(variable);
 		
 	}
 
 	void QueryExpressionBody(
-#line  2498 "cs.ATG" 
+#line  2497 "cs.ATG" 
 ref QueryExpression q) {
 
-#line  2499 "cs.ATG" 
+#line  2498 "cs.ATG" 
 		QueryExpressionFromClause fromClause;     QueryExpressionWhereClause whereClause;
 		QueryExpressionLetClause letClause;       QueryExpressionJoinClause joinClause;
 		QueryExpressionOrderClause orderClause;
 		QueryExpressionSelectClause selectClause; QueryExpressionGroupClause groupClause;
 		
-		while (StartOf(39)) {
+		while (StartOf(40)) {
 			if (la.kind == 137) {
 				QueryExpressionFromClause(
-#line  2505 "cs.ATG" 
+#line  2504 "cs.ATG" 
 out fromClause);
 
-#line  2505 "cs.ATG" 
+#line  2504 "cs.ATG" 
 				SafeAdd<QueryExpressionClause>(q, q.MiddleClauses, fromClause); 
 			} else if (la.kind == 127) {
 				QueryExpressionWhereClause(
-#line  2506 "cs.ATG" 
+#line  2505 "cs.ATG" 
 out whereClause);
 
-#line  2506 "cs.ATG" 
+#line  2505 "cs.ATG" 
 				SafeAdd<QueryExpressionClause>(q, q.MiddleClauses, whereClause); 
 			} else if (la.kind == 141) {
 				QueryExpressionLetClause(
-#line  2507 "cs.ATG" 
+#line  2506 "cs.ATG" 
 out letClause);
 
-#line  2507 "cs.ATG" 
+#line  2506 "cs.ATG" 
 				SafeAdd<QueryExpressionClause>(q, q.MiddleClauses, letClause); 
 			} else if (la.kind == 142) {
 				QueryExpressionJoinClause(
-#line  2508 "cs.ATG" 
+#line  2507 "cs.ATG" 
 out joinClause);
 
-#line  2508 "cs.ATG" 
+#line  2507 "cs.ATG" 
 				SafeAdd<QueryExpressionClause>(q, q.MiddleClauses, joinClause); 
 			} else {
 				QueryExpressionOrderByClause(
-#line  2509 "cs.ATG" 
+#line  2508 "cs.ATG" 
 out orderClause);
 
-#line  2509 "cs.ATG" 
+#line  2508 "cs.ATG" 
 				SafeAdd<QueryExpressionClause>(q, q.MiddleClauses, orderClause); 
 			}
 		}
 		if (la.kind == 133) {
 			QueryExpressionSelectClause(
-#line  2511 "cs.ATG" 
+#line  2510 "cs.ATG" 
 out selectClause);
 
-#line  2511 "cs.ATG" 
+#line  2510 "cs.ATG" 
 			q.SelectOrGroupClause = selectClause; 
 		} else if (la.kind == 134) {
 			QueryExpressionGroupClause(
-#line  2512 "cs.ATG" 
+#line  2511 "cs.ATG" 
 out groupClause);
 
-#line  2512 "cs.ATG" 
+#line  2511 "cs.ATG" 
 			q.SelectOrGroupClause = groupClause; 
 		} else SynErr(216);
 		if (la.kind == 136) {
 			QueryExpressionIntoClause(
-#line  2514 "cs.ATG" 
+#line  2513 "cs.ATG" 
 ref q);
 		}
 	}
 
 	void QueryExpressionFromOrJoinClause(
-#line  2488 "cs.ATG" 
+#line  2487 "cs.ATG" 
 out CollectionRangeVariable variable) {
 
-#line  2489 "cs.ATG" 
+#line  2488 "cs.ATG" 
 		TypeReference type; Expression expr; variable = new CollectionRangeVariable(); 
 
-#line  2491 "cs.ATG" 
+#line  2490 "cs.ATG" 
 		variable.Type = null; 
 		if (
-#line  2492 "cs.ATG" 
+#line  2491 "cs.ATG" 
 IsLocalVarDecl()) {
 			Type(
-#line  2492 "cs.ATG" 
+#line  2491 "cs.ATG" 
 out type);
 
-#line  2492 "cs.ATG" 
+#line  2491 "cs.ATG" 
 			variable.Type = type; 
 		}
 		Identifier();
 
-#line  2493 "cs.ATG" 
+#line  2492 "cs.ATG" 
 		variable.Identifier = t.val; 
 		Expect(81);
 		Expr(
-#line  2495 "cs.ATG" 
+#line  2494 "cs.ATG" 
 out expr);
 
-#line  2495 "cs.ATG" 
+#line  2494 "cs.ATG" 
 		variable.Expression = expr; 
 	}
 
 	void QueryExpressionJoinClause(
-#line  2467 "cs.ATG" 
+#line  2466 "cs.ATG" 
 out QueryExpressionJoinClause jc) {
 
-#line  2468 "cs.ATG" 
+#line  2467 "cs.ATG" 
 		jc = new QueryExpressionJoinClause(); jc.StartLocation = la.Location; 
 		Expression expr;
 		CollectionRangeVariable variable;
 		
 		Expect(142);
 		QueryExpressionFromOrJoinClause(
-#line  2474 "cs.ATG" 
+#line  2473 "cs.ATG" 
 out variable);
 		Expect(143);
 		Expr(
-#line  2476 "cs.ATG" 
+#line  2475 "cs.ATG" 
 out expr);
 
-#line  2476 "cs.ATG" 
+#line  2475 "cs.ATG" 
 		jc.OnExpression = expr; 
 		Expect(144);
 		Expr(
-#line  2478 "cs.ATG" 
+#line  2477 "cs.ATG" 
 out expr);
 
-#line  2478 "cs.ATG" 
+#line  2477 "cs.ATG" 
 		jc.EqualsExpression = expr; 
 		if (la.kind == 136) {
 			lexer.NextToken();
 			Identifier();
 
-#line  2480 "cs.ATG" 
+#line  2479 "cs.ATG" 
 			jc.IntoIdentifier = t.val; 
 		}
 
-#line  2483 "cs.ATG" 
+#line  2482 "cs.ATG" 
 		jc.EndLocation = t.EndLocation;
 		jc.Source = variable;
 		
 	}
 
 	void QueryExpressionWhereClause(
-#line  2517 "cs.ATG" 
+#line  2516 "cs.ATG" 
 out QueryExpressionWhereClause wc) {
 
-#line  2518 "cs.ATG" 
+#line  2517 "cs.ATG" 
 		Expression expr; wc = new QueryExpressionWhereClause(); wc.StartLocation = la.Location; 
 		Expect(127);
 		Expr(
-#line  2521 "cs.ATG" 
+#line  2520 "cs.ATG" 
 out expr);
 
-#line  2521 "cs.ATG" 
+#line  2520 "cs.ATG" 
 		wc.Condition = expr; 
 
-#line  2522 "cs.ATG" 
+#line  2521 "cs.ATG" 
 		wc.EndLocation = t.EndLocation; 
 	}
 
 	void QueryExpressionLetClause(
-#line  2525 "cs.ATG" 
+#line  2524 "cs.ATG" 
 out QueryExpressionLetClause wc) {
 
-#line  2526 "cs.ATG" 
+#line  2525 "cs.ATG" 
 		Expression expr; wc = new QueryExpressionLetClause(); wc.StartLocation = la.Location; 
 		Expect(141);
 		Identifier();
 
-#line  2529 "cs.ATG" 
+#line  2528 "cs.ATG" 
 		wc.Identifier = t.val; 
 		Expect(3);
 		Expr(
-#line  2531 "cs.ATG" 
+#line  2530 "cs.ATG" 
 out expr);
 
-#line  2531 "cs.ATG" 
+#line  2530 "cs.ATG" 
 		wc.Expression = expr; 
 
-#line  2532 "cs.ATG" 
+#line  2531 "cs.ATG" 
 		wc.EndLocation = t.EndLocation; 
 	}
 
 	void QueryExpressionOrderByClause(
-#line  2535 "cs.ATG" 
+#line  2534 "cs.ATG" 
 out QueryExpressionOrderClause oc) {
 
-#line  2536 "cs.ATG" 
+#line  2535 "cs.ATG" 
 		QueryExpressionOrdering ordering; oc = new QueryExpressionOrderClause(); oc.StartLocation = la.Location; 
 		Expect(140);
 		QueryExpressionOrdering(
-#line  2539 "cs.ATG" 
+#line  2538 "cs.ATG" 
 out ordering);
 
-#line  2539 "cs.ATG" 
+#line  2538 "cs.ATG" 
 		SafeAdd(oc, oc.Orderings, ordering); 
 		while (la.kind == 14) {
 			lexer.NextToken();
 			QueryExpressionOrdering(
-#line  2541 "cs.ATG" 
+#line  2540 "cs.ATG" 
 out ordering);
 
-#line  2541 "cs.ATG" 
+#line  2540 "cs.ATG" 
 			SafeAdd(oc, oc.Orderings, ordering); 
 		}
 
-#line  2543 "cs.ATG" 
+#line  2542 "cs.ATG" 
 		oc.EndLocation = t.EndLocation; 
 	}
 
 	void QueryExpressionSelectClause(
-#line  2556 "cs.ATG" 
+#line  2555 "cs.ATG" 
 out QueryExpressionSelectClause sc) {
 
-#line  2557 "cs.ATG" 
+#line  2556 "cs.ATG" 
 		Expression expr; sc = new QueryExpressionSelectClause(); sc.StartLocation = la.Location; 
 		Expect(133);
 		Expr(
-#line  2560 "cs.ATG" 
+#line  2559 "cs.ATG" 
 out expr);
 
-#line  2560 "cs.ATG" 
+#line  2559 "cs.ATG" 
 		sc.Projection = expr; 
 
-#line  2561 "cs.ATG" 
+#line  2560 "cs.ATG" 
 		sc.EndLocation = t.EndLocation; 
 	}
 
 	void QueryExpressionGroupClause(
-#line  2564 "cs.ATG" 
+#line  2563 "cs.ATG" 
 out QueryExpressionGroupClause gc) {
 
-#line  2565 "cs.ATG" 
+#line  2564 "cs.ATG" 
 		Expression expr; gc = new QueryExpressionGroupClause(); gc.StartLocation = la.Location; 
 		Expect(134);
 		Expr(
-#line  2568 "cs.ATG" 
+#line  2567 "cs.ATG" 
 out expr);
 
-#line  2568 "cs.ATG" 
+#line  2567 "cs.ATG" 
 		gc.Projection = expr; 
 		Expect(135);
 		Expr(
-#line  2570 "cs.ATG" 
+#line  2569 "cs.ATG" 
 out expr);
 
-#line  2570 "cs.ATG" 
+#line  2569 "cs.ATG" 
 		gc.GroupBy = expr; 
 
-#line  2571 "cs.ATG" 
+#line  2570 "cs.ATG" 
 		gc.EndLocation = t.EndLocation; 
 	}
 
 	void QueryExpressionIntoClause(
-#line  2574 "cs.ATG" 
+#line  2573 "cs.ATG" 
 ref QueryExpression q) {
 
-#line  2575 "cs.ATG" 
+#line  2574 "cs.ATG" 
 		QueryExpression firstQuery = q;
 		QueryExpression continuedQuery = new QueryExpression(); 
 		continuedQuery.StartLocation = q.StartLocation;
@@ -5897,43 +5890,43 @@ ref QueryExpression q) {
 		Expect(136);
 		Identifier();
 
-#line  2590 "cs.ATG" 
+#line  2589 "cs.ATG" 
 		fromVariable.Identifier = t.val; 
 
-#line  2591 "cs.ATG" 
+#line  2590 "cs.ATG" 
 		continuedQuery.FromClause.EndLocation = t.EndLocation; 
 		QueryExpressionBody(
-#line  2592 "cs.ATG" 
+#line  2591 "cs.ATG" 
 ref q);
 	}
 
 	void QueryExpressionOrdering(
-#line  2546 "cs.ATG" 
+#line  2545 "cs.ATG" 
 out QueryExpressionOrdering ordering) {
 
-#line  2547 "cs.ATG" 
+#line  2546 "cs.ATG" 
 		Expression expr; ordering = new QueryExpressionOrdering(); ordering.StartLocation = la.Location; 
 		Expr(
-#line  2549 "cs.ATG" 
+#line  2548 "cs.ATG" 
 out expr);
 
-#line  2549 "cs.ATG" 
+#line  2548 "cs.ATG" 
 		ordering.Criteria = expr; 
 		if (la.kind == 138 || la.kind == 139) {
 			if (la.kind == 138) {
 				lexer.NextToken();
 
-#line  2550 "cs.ATG" 
+#line  2549 "cs.ATG" 
 				ordering.Direction = QueryExpressionOrderingDirection.Ascending; 
 			} else {
 				lexer.NextToken();
 
-#line  2551 "cs.ATG" 
+#line  2550 "cs.ATG" 
 				ordering.Direction = QueryExpressionOrderingDirection.Descending; 
 			}
 		}
 
-#line  2553 "cs.ATG" 
+#line  2552 "cs.ATG" 
 		ordering.EndLocation = t.EndLocation; 
 	}
 
@@ -6189,7 +6182,7 @@ out expr);
 	{x,T,x,T, T,T,T,T, T,T,x,T, T,T,T,T, T,T,T,T, T,T,T,T, x,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, x,T,T,x, T,x,T,x, x,T,x,T, T,x,T,x, T,x,T,x, T,T,T,T, x,x,T,T, x,x,x,x, T,x,T,T, T,T,x,T, x,T,x,T, x,x,T,x, T,T,T,T, x,x,T,T, T,x,x,T, T,T,x,x, x,x,x,x, T,T,x,T, T,x,T,T, T,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
 	{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,T,x, x,T,x,x, x,x,T,x, x,x,T,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,T,x, x,x,x,T, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, T,x,x,x, T,x,x,x, x,x,x,x, T,T,x,x, T,x,x,T, x,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
-	{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,T,x, x,T,x,x, x,x,T,x, x,x,T,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,T,x, x,x,x,T, x,x,x,T, x,T,x,T, x,x,x,x, T,x,T,x, T,x,x,x, T,x,x,x, x,x,x,x, T,T,x,x, T,x,x,T, x,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
+	{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,T,x, x,T,x,x, x,x,T,x, x,x,T,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,T,x, x,x,x,T, x,x,x,T, x,T,x,T, x,x,x,x, T,x,T,x, T,x,x,x, T,x,x,T, x,x,x,x, T,T,x,x, T,x,x,T, x,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, T,x,T,x, x,T,x,T, T,x,T,x, T,x,T,x, T,T,T,T, x,x,T,T, x,x,x,x, T,x,T,T, T,x,x,T, x,T,x,T, x,x,T,x, T,T,T,T, x,x,T,T, T,x,x,T, T,T,x,x, x,x,x,x, T,T,x,T, T,x,T,T, T,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, T,x,T,x, x,T,x,T, T,x,T,x, T,x,T,x, T,T,T,T, x,x,T,T, x,x,x,x, T,x,T,T, T,x,x,T, x,T,x,T, x,x,T,x, T,T,T,T, x,x,T,T, T,x,x,T, T,T,x,x, x,x,x,x, T,T,x,T, T,x,T,T, T,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, T,x,T,x, x,T,x,T, T,x,T,x, T,x,T,x, T,T,T,T, x,x,T,T, x,x,x,x, T,x,T,T, T,x,x,T, x,T,x,T, x,x,T,x, T,T,T,T, x,x,T,T, T,x,x,T, T,T,x,x, x,x,x,x, T,T,x,T, T,x,T,T, T,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
@@ -6202,6 +6195,7 @@ out expr);
 	{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, T,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
 	{x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,T,x, x,T,x,x, x,x,T,x, x,x,T,x, x,T,x,x, x,x,x,T, x,x,x,x, x,x,T,x, x,x,x,T, x,x,x,T, x,x,x,x, x,x,x,x, x,x,T,x, T,x,x,x, T,x,x,x, x,x,x,x, T,T,x,x, T,x,x,T, x,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, T,x,x,x, x,x,x,x, x,x,x,x, T,T,x,x, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
+	{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,T, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,T, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},
 	{x,T,T,x, T,T,T,x, x,x,x,T, x,x,x,x, T,x,x,x, T,x,x,x, T,x,x,T, T,x,x,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,T,T,x, x,T,T,x, T,T,T,T, T,T,T,x, x,x,x,x, T,x,T,T, T,T,T,T, x,x,T,x, x,x,T,T, x,T,T,T, x,x,x,x, x,x,x,x, x,T,T,x, T,T,x,x, T,x,T,T, T,T,T,T, T,T,T,T, T,T,x,T, x,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{x,T,T,x, T,T,T,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, T,x,x,T, T,x,x,T, T,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,T, T,x,T,x, x,T,T,x, x,x,T,T, T,x,T,x, x,x,x,x, T,x,x,T, x,x,x,x, x,x,T,x, x,x,x,T, x,T,T,T, x,T,x,x, x,x,x,x, T,x,T,x, T,T,x,x, T,x,x,T, x,T,x,T, T,T,T,x, T,x,x,T, x,x,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,T,T,T, T,x,x},
 	{x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,T,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, T,x,x,x, x,x,x,x, x,x,x,x, T,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,T,x,x, x,x,x,x, x,x,x,x, x,x,x,x, x,x,x},

--- a/src/Libraries/NRefactory/Project/Src/Parser/CSharp/cs.ATG
+++ b/src/Libraries/NRefactory/Project/Src/Parser/CSharp/cs.ATG
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text;
+using System.Linq;
 using ICSharpCode.NRefactory.Parser;
 using ICSharpCode.NRefactory.Ast;
 using ASTAttribute = ICSharpCode.NRefactory.Ast.Attribute;
@@ -673,6 +674,7 @@ FixedParameter<out ParameterDeclarationExpression p>
 		"ref"    (. mod = ParameterModifiers.Ref; .)
 		| "out"  (. mod = ParameterModifiers.Out; .)
 		| "params" (. mod = ParameterModifiers.Params; .)
+		| "this" (. mod = ParameterModifiers.This; .)
 	]
 	Type<out type>
 	Identifier (. p = new ParameterDeclarationExpression(type, t.val, mod); .)
@@ -756,7 +758,6 @@ StructMemberDecl<ModifierList m, List<AttributeSection> attributes>
 	BlockStatement stmt = null;
 	List<TemplateDefinition> templates = new List<TemplateDefinition>();
 	TypeReference explicitInterface = null;
-	bool isExtensionMethod = false;
 .)
 =
 	/*--- constant declaration: */         (. m.Check(Modifiers.Constants); .)
@@ -792,7 +793,6 @@ StructMemberDecl<ModifierList m, List<AttributeSection> attributes>
 	[ TypeParameterList<templates> ]
 	
 	"("
-	[ "this" (. isExtensionMethod = true; /* C# 3.0 */ .) ]
 	[ FormalParameterList<p> ] ")"
 	(.	MethodDeclaration methodDeclaration = new MethodDeclaration {
 			Name = qualident,
@@ -803,7 +803,7 @@ StructMemberDecl<ModifierList m, List<AttributeSection> attributes>
 			StartLocation = m.GetDeclarationLocation(startPos),
 			EndLocation = t.EndLocation,
 			Templates = templates,
-			IsExtensionMethod = isExtensionMethod
+			IsExtensionMethod = p.Any(param => param.ParamModifier == ParameterModifiers.This)
 		};
 		if (explicitInterface != null)
 			SafeAdd(methodDeclaration, methodDeclaration.InterfaceImplementations, new InterfaceImplementation(explicitInterface, qualident));
@@ -1014,7 +1014,6 @@ StructMemberDecl<ModifierList m, List<AttributeSection> attributes>
 				/* .NET 2.0 */
 				[ TypeParameterList<templates> ]
 				"(" 
-				[ "this" (. isExtensionMethod = true; .) ]
 				[ FormalParameterList<p> ] ")"
 				(.
 					MethodDeclaration methodDeclaration = new MethodDeclaration {
@@ -1028,7 +1027,7 @@ StructMemberDecl<ModifierList m, List<AttributeSection> attributes>
 						methodDeclaration.InterfaceImplementations.Add(new InterfaceImplementation(explicitInterface, qualident));
 					methodDeclaration.StartLocation = m.GetDeclarationLocation(startPos);
 					methodDeclaration.EndLocation   = t.EndLocation;
-					methodDeclaration.IsExtensionMethod = isExtensionMethod;
+					methodDeclaration.IsExtensionMethod = p.Any(param => param.ParamModifier == ParameterModifiers.This);
 					methodDeclaration.Templates = templates;
 					AddChild(methodDeclaration);
 				                                       .)

--- a/src/Libraries/NRefactory/Test/Parser/TypeLevel/MethodDeclarationTests.cs
+++ b/src/Libraries/NRefactory/Test/Parser/TypeLevel/MethodDeclarationTests.cs
@@ -239,13 +239,12 @@ namespace ICSharpCode.NRefactory.Tests.Ast
 			Assert.AreEqual("T", md.Templates[0].Name);
 			Assert.AreEqual(0, md.Templates[0].Bases.Count);
 		}
-		
-		[Test]
-		public void CSharpExtensionMethodTest()
+
+        [TestCase("public static int ToInt32(              this string s) { return int.Parse(s); }")]
+        [TestCase("public static int ToInt32([MyAttribute] this string s) { return int.Parse(s); }")]
+		public void CSharpExtensionMethodTest(string methodDeclaration)
 		{
-			MethodDeclaration md = ParseUtilCSharp.ParseTypeMember<MethodDeclaration>(
-				"public static int ToInt32(this string s) { return int.Parse(s); }"
-			);
+			MethodDeclaration md = ParseUtilCSharp.ParseTypeMember<MethodDeclaration>(methodDeclaration);
 			Assert.AreEqual("ToInt32", md.Name);
 			Assert.IsTrue(md.IsExtensionMethod);
 			Assert.AreEqual("s", md.Parameters[0].ParameterName);

--- a/src/Main/ICSharpCode.SharpDevelop.Dom/Project/Src/Interfaces/ParameterModifiers.cs
+++ b/src/Main/ICSharpCode.SharpDevelop.Dom/Project/Src/Interfaces/ParameterModifiers.cs
@@ -15,6 +15,7 @@ namespace ICSharpCode.SharpDevelop.Dom
 		Out = 2,
 		Ref = 4,
 		Params = 8,
-		Optional = 16
+        Optional = 16,
+        This = 32
 	}
 }


### PR DESCRIPTION
See: http://community.sharpdevelop.net/forums/p/13779/36966.aspx
