### PR TITLE
Add a button to load current project assembly to CodeQuality

### DIFF
--- a/src/AddIns/Analysis/CodeQuality/Gui/MainView.xaml
+++ b/src/AddIns/Analysis/CodeQuality/Gui/MainView.xaml
@@ -9,6 +9,7 @@
 	<DockPanel>
 		<ToolBar DockPanel.Dock="Top">
 			<Button Click="AddAssemblyClick">Add Assembly</Button>
+			<Button Click="AddCurrentProjectAssemblyClick">Add Current Project Assembly</Button>
 				
 			<Menu Background="White" x:Name="printMenu" Visibility="Hidden">
 				<MenuItem Header="Reports">

--- a/src/AddIns/Analysis/CodeQuality/Gui/MainView.xaml.cs
+++ b/src/AddIns/Analysis/CodeQuality/Gui/MainView.xaml.cs
@@ -32,6 +32,7 @@ using ICSharpCode.CodeQuality.Engine.Dom;
 using ICSharpCode.CodeQuality.Reporting;
 using ICSharpCode.Reports.Core.WpfReportViewer;
 using ICSharpCode.SharpDevelop.Gui;
+using ICSharpCode.SharpDevelop.Project;
 using Microsoft.Win32;
 
 namespace ICSharpCode.CodeQuality.Gui
@@ -70,6 +71,23 @@ namespace ICSharpCode.CodeQuality.Gui
 			UpdateUI();
 		}
 		
+		void AddCurrentProjectAssemblyClick(object sender, RoutedEventArgs e)
+		{
+			if (ProjectService.CurrentProject == null)
+				return;
+			
+			string fileName = ProjectService.CurrentProject.OutputAssemblyFullPath;
+			if (string.IsNullOrEmpty(fileName))
+			{
+				MessageBox.Show("Project output assembly not found! Please build it first!");
+				return;
+			}
+
+			introBlock.Visibility = Visibility.Collapsed;
+			this.fileNames.Add(fileName);
+			Analyse(new string[] { fileName });
+			UpdateUI();
+		}
 		
 		void Analyse (string[] fileNames)
 		{


### PR DESCRIPTION
More convenient way to load / refresh current project assembly to CodeQuality

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
