### PR TITLE
C# Main() should not be public

### DIFF
--- a/data/templates/project/CSharp/ConsoleProject.xpt
+++ b/data/templates/project/CSharp/ConsoleProject.xpt
@@ -36,7 +36,7 @@ namespace ${StandardNamespace}
 {
 	class Program
 	{
-		public static void Main(string[] args)
+		static void Main(string[] args)
 		{
 			Console.WriteLine("Hello World!");
 			


### PR DESCRIPTION
C# Main() should not be public - see
http://msdn.microsoft.com/en-us/library/vstudio/acy3edy3.aspx.

Else recursion and stack-overflow if Main() is invoked in same
assembly (i.e. not CLR).
