### PR TITLE
A "Git Show Log..." menu command

### DIFF
--- a/src/AddIns/VersionControl/GitAddIn/GitAddIn.addin
+++ b/src/AddIns/VersionControl/GitAddIn/GitAddIn.addin
@@ -36,6 +36,10 @@
 			          label = "Git ${res:AddIns.Subversion.Diff}..."
 			          icon  = "Svn.Diff"
 			          class = "ICSharpCode.GitAddIn.GitDiffCommand"/>
+		
+			<MenuItem id = "GitLog"
+			          label = "Git ${res:AddIns.Subversion.ShowLog}..."
+			          class = "ICSharpCode.GitAddIn.GitLogCommand"/>
 		</Condition>
 	</Path>
 	

--- a/src/AddIns/VersionControl/GitAddIn/Src/Commands.cs
+++ b/src/AddIns/VersionControl/GitAddIn/Src/Commands.cs
@@ -92,4 +92,12 @@ namespace ICSharpCode.GitAddIn
 			GitGuiWrapper.Diff(filename, callback);
 		}
 	}
+	
+	public class GitLogCommand : GitCommand
+	{
+		protected override void Run(string filename, Action callback)
+		{
+			GitGuiWrapper.Log(filename, callback);
+		}
+	}
 }

--- a/src/AddIns/VersionControl/GitAddIn/Src/GitGuiWrapper.cs
+++ b/src/AddIns/VersionControl/GitAddIn/Src/GitGuiWrapper.cs
@@ -95,5 +95,10 @@ namespace ICSharpCode.GitAddIn
 		{
 			Proc("diff", fileName, callback);
 		}
+		
+		public static void Log(string fileName, Action callback)
+		{
+			Proc("log", fileName, callback);
+		}
 	}
 }


### PR DESCRIPTION
Besides the "Git Commit" and "Git Diff" I found a "Git Show Log" command very useful. It simply calls TortoiseGit's revision list for a specific file.
