### PR TITLE
GotoDialog: Restored search in type members with dot "." in SD 5 + input completion by TAB

### DIFF
--- a/src/Main/Base/Project/Src/Gui/Dialogs/GotoDialog.xaml
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/GotoDialog.xaml
@@ -15,6 +15,11 @@
 				</DataTrigger>
 			</Style.Triggers>
 		</Style>
+		
+		<Style x:Key="ListItemImageStyle" TargetType="{x:Type Image}">
+			<Setter Property="Width" Value="16" />
+			<Setter Property="Height" Value="16" />
+		</Style>
 	</Window.Resources>
 	
 	<Grid>
@@ -46,7 +51,7 @@
 			<ListBox.ItemTemplate>
 				<DataTemplate>
 					<StackPanel Orientation="Horizontal">
-						<Image Source="{Binding ImageSource}"/>
+						<Image Source="{Binding ImageSource}" Style="{StaticResource ListItemImageStyle}"/>
 						<TextBlock Text="{Binding Text}" Margin="4,0,0,0" Style="{StaticResource ListItemTextStyle}"/>
 					</StackPanel>
 				</DataTemplate>


### PR DESCRIPTION
The GotoDialog in SD 4.x had the useful feature to type a "." to search for the members of a class, for example "gotodial.textboxt" to find and navigate to "GotoDialog.textBoxTextChanged" method. This didn't work anymore in SD 5 - probably after migrating to NRefactory? I've added it back.

Another little neat feature is the possibility to press TAB to complete the search input using the selected item in list.
For example, to quickly navigate to "GotoDialog.xaml": Type "gotodi" -> "GotoDialog" is already the first result in list -> press TAB, so input field is completed to "GotoDialog" -> now type ".xaml" and ENTER.

Found it useful for daily code navigation...
