### PR TITLE
Make members in LineNumberMargin protected so derived classes can specialize it and still use the same typeface, emSize & maxLineNumberLength

### DIFF
--- a/src/Libraries/AvalonEdit/ICSharpCode.AvalonEdit/Editing/LineNumberMargin.cs
+++ b/src/Libraries/AvalonEdit/ICSharpCode.AvalonEdit/Editing/LineNumberMargin.cs
@@ -29,8 +29,8 @@ namespace ICSharpCode.AvalonEdit.Editing
 		
 		TextArea textArea;
 		
-		Typeface typeface;
-		double emSize;
+		protected Typeface typeface;
+		protected double emSize;
 		
 		/// <inheritdoc/>
 		protected override Size MeasureOverride(Size availableSize)
@@ -114,7 +114,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 			return ReceiveWeakEvent(managerType, sender, e);
 		}
 		
-		int maxLineNumberLength = 1;
+		protected int maxLineNumberLength = 1;
 		
 		void OnDocumentLineCountChanged()
 		{


### PR DESCRIPTION
This helps in customizing the line numbers margin which is what I ran into and had to hack up things. 
This link was where I took suggestions from and ran into problems trying to replicate the same functionality for OnRender where I wanted the logic to be the same as the original class but just change the line number values.
http://community.sharpdevelop.net/forums/t/11706.aspx
