### PR TITLE
Add tgit.icon in .tgitconfig

### DIFF
--- a/.tgitconfig
+++ b/.tgitconfig
@@ -1,0 +1,2 @@
+[tgit]
+	icon = src/Main/StartUp/Project/Resources/SharpDevelop.ico


### PR DESCRIPTION
This is a new feature in TortoiseGit 1.8.6,
which allows to show SherpDevelop icon as taskbar overlay icon

![tgit icon-help](https://f.cloud.github.com/assets/791115/1322125/1325c0b6-3414-11e3-8331-b2259e6ee61c.png)

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
