### PR TITLE
Fixes for using-Refactorings

### DIFF
--- a/src/AddIns/Misc/PackageManagement/Project/Src/DocumentNamespaceCreator.cs
+++ b/src/AddIns/Misc/PackageManagement/Project/Src/DocumentNamespaceCreator.cs
@@ -20,7 +20,7 @@ namespace ICSharpCode.PackageManagement
 				IViewContent view = FileService.OpenFile(compilationUnit.FileName);
 				var textEditor = view as ITextEditorProvider;
 				IDocument document = textEditor.TextEditor.Document;
-				NamespaceRefactoringService.AddUsingDeclaration(compilationUnit, document, newNamespace, false);
+				NamespaceRefactoringService.AddUsingDeclaration(compilationUnit, document, compilationUnit.UsingScope, newNamespace, false);
 			}
 		}
 	}

--- a/src/AddIns/Misc/SharpRefactoring/Project/Src/ContextActions/AddUsing.cs
+++ b/src/AddIns/Misc/SharpRefactoring/Project/Src/ContextActions/AddUsing.cs
@@ -51,8 +51,9 @@ namespace SharpRefactoring.ContextActions
 			foreach (IProjectContent content in pc.ThreadSafeGetReferencedContents())
 				SearchAllExtensionMethodsWithName(results, content, rr.CallName);
 			
+			var compilationUnit = context.CurrentParseInformation.CompilationUnit;
 			foreach (IClass c in results) {
-				yield return new RefactoringService.AddUsingAction(context.CurrentParseInformation.CompilationUnit, context.Editor, c.Namespace);
+				yield return new RefactoringService.AddUsingAction(compilationUnit, context.Editor, c.Namespace, compilationUnit.UsingScope);
 			}
 		}
 		
@@ -92,7 +93,7 @@ namespace SharpRefactoring.ContextActions
 			}
 			
 			foreach (IClass c in results) {
-				yield return new RefactoringService.AddUsingAction(unit, context.Editor, c.Namespace);
+				yield return new RefactoringService.AddUsingAction(unit, context.Editor, c.Namespace, unit.UsingScope);
 			}
 		}
 		

--- a/src/AddIns/Misc/SharpRefactoring/Project/Src/MenuItemFactories/ResolveAttribute.cs
+++ b/src/AddIns/Misc/SharpRefactoring/Project/Src/MenuItemFactories/ResolveAttribute.cs
@@ -73,7 +73,7 @@ namespace SharpRefactoring
 				subItem.Icon = ClassBrowserIconService.Namespace.CreateImage();
 				item.Items.Add(subItem);
 				subItem.Click += delegate {
-					NamespaceRefactoringService.AddUsingDeclaration(unit, context.Editor.Document, newNamespace, true);
+					NamespaceRefactoringService.AddUsingDeclaration(unit, context.Editor.Document, unit.UsingScope, newNamespace, true);
 					ParserService.BeginParse(context.Editor.FileName, context.Editor.Document);
 				};
 			}

--- a/src/AddIns/Misc/SharpRefactoring/Project/Src/MenuItemFactories/ResolveExtensionMethod.cs
+++ b/src/AddIns/Misc/SharpRefactoring/Project/Src/MenuItemFactories/ResolveExtensionMethod.cs
@@ -51,7 +51,7 @@ namespace SharpRefactoring
 				subItem.Icon = ClassBrowserIconService.Namespace.CreateImage();
 				item.Items.Add(subItem);
 				subItem.Click += delegate {
-					NamespaceRefactoringService.AddUsingDeclaration(context.CompilationUnit, context.Editor.Document, newNamespace, true);
+					NamespaceRefactoringService.AddUsingDeclaration(context.CompilationUnit, context.Editor.Document, context.CompilationUnit.UsingScope, newNamespace, true);
 					ParserService.BeginParse(context.Editor.FileName, context.Editor.Document);
 				};
 			}

--- a/src/Main/Base/Project/Src/Editor/CodeCompletion/CodeCompletionItemProvider.cs
+++ b/src/Main/Base/Project/Src/Editor/CodeCompletion/CodeCompletionItemProvider.cs
@@ -292,7 +292,7 @@ namespace ICSharpCode.SharpDevelop.Editor.CodeCompletion
 				
 				if (addUsing && nameResult != null && nameResult.CallingClass != null) {
 					var cu = nameResult.CallingClass.CompilationUnit;
-					NamespaceRefactoringService.AddUsingDeclaration(cu, document, selectedClass.Namespace, false);
+					NamespaceRefactoringService.AddUsingDeclaration(cu, document, nameResult.CallingClass.UsingScope, selectedClass.Namespace, false);
 					ParserService.BeginParse(editor.FileName, document);
 				}
 			} else {

--- a/src/Main/Base/Project/Src/Services/RefactoringService/RefactoringService.cs
+++ b/src/Main/Base/Project/Src/Services/RefactoringService/RefactoringService.cs
@@ -648,7 +648,7 @@ namespace ICSharpCode.SharpDevelop.Refactoring
 			}
 			foreach (IClass c in searchResults) {
 				string newNamespace = c.Namespace;
-				yield return new AddUsingAction(callingClass.CompilationUnit, editor, newNamespace);
+				yield return new AddUsingAction(callingClass.CompilationUnit, editor, newNamespace, callingClass.UsingScope);
 			}
 		}
 		
@@ -666,8 +666,9 @@ namespace ICSharpCode.SharpDevelop.Refactoring
 			public ICompilationUnit CompilationUnit { get; private set; }
 			public ITextEditor Editor { get; private set; }
 			public string NewNamespace { get; private set; }
+			public IUsingScope UsingScope { get; private set; }
 			
-			public AddUsingAction(ICompilationUnit compilationUnit, ITextEditor editor, string newNamespace)
+			public AddUsingAction(ICompilationUnit compilationUnit, ITextEditor editor, string newNamespace, IUsingScope usingScope)
 			{
 				if (compilationUnit == null)
 					throw new ArgumentNullException("compilationUnit");
@@ -675,14 +676,17 @@ namespace ICSharpCode.SharpDevelop.Refactoring
 					throw new ArgumentNullException("editor");
 				if (newNamespace == null)
 					throw new ArgumentNullException("newNamespace");
+				if (usingScope == null)
+					throw new ArgumentNullException("usingScope");
 				this.CompilationUnit = compilationUnit;
 				this.Editor = editor;
 				this.NewNamespace = newNamespace;
+				this.UsingScope = usingScope;
 			}
 			
 			public void Execute()
 			{
-				NamespaceRefactoringService.AddUsingDeclaration(CompilationUnit, Editor.Document, NewNamespace, true);
+				NamespaceRefactoringService.AddUsingDeclaration(CompilationUnit, Editor.Document, UsingScope, NewNamespace, true);
 				ParserService.BeginParse(Editor.FileName, Editor.Document);
 			}
 			


### PR DESCRIPTION
1. Extended 'Add Using' function by involving scope. New usings are
   added to the inner (namespace-)scope, if it does have usings already.
2. Extended 'Remove unused import statements' function by removing and
   sorting inside of scopes.

My changes are released under BSD License (according to http://laputa.sharpdevelop.net/PatchSizedContributionsWithoutJCA.aspx I don't have to sign and send the JCA then). If this doesn't work this way anymore, let me know.
