### PR TITLE
Fix indentation for 'Move class to File' function

### DIFF
--- a/src/Main/ICSharpCode.SharpDevelop.Dom/Project/Src/Refactoring/NRefactoryRefactoringProvider.cs
+++ b/src/Main/ICSharpCode.SharpDevelop.Dom/Project/Src/Refactoring/NRefactoryRefactoringProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 using ICSharpCode.NRefactory.Ast;
 using ICSharpCode.NRefactory.PrettyPrinter;
@@ -430,6 +431,11 @@ namespace ICSharpCode.SharpDevelop.Dom.Refactoring
 				}
 			}
 			IOutputAstVisitor outputVisitor = (language==NR.SupportedLanguage.CSharp) ? new CSharpOutputVisitor() : (IOutputAstVisitor)new VBNetOutputVisitor();
+			var match = Regex.Match(codeForNewType, @"^([\s]+)", RegexOptions.Multiline);
+			if (match != null && !string.IsNullOrEmpty(match.Groups[0].Value)) {
+				outputVisitor.Options.IndentationChar = match.Groups[0].Value[0];
+			}
+			
 			using (SpecialNodesInserter.Install(comments, outputVisitor)) {
 				parser.CompilationUnit.AcceptVisitor(outputVisitor, null);
 			}


### PR DESCRIPTION
'Move class to File' function did always use tab as indentation
character. As space user you always had to convert the tabs to spaces by
hand afterwards. This fix tries to find and set the right indentation
character. If no indentation character is found, it falls back to tab.

My changes are released under BSD License (according to http://laputa.sharpdevelop.net/PatchSizedContributionsWithoutJCA.aspx I don't have to sign and send the JCA then). If this doesn't work this way anymore, let me know.
