### PR TITLE
Fixed SD-1931 - Dragging Pointer from toolbox to WPF designer throws exception.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.AddIn/Src/WpfToolbox.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.AddIn/Src/WpfToolbox.cs
@@ -183,7 +183,13 @@ namespace ICSharpCode.WpfDesign.AddIn
 				if (this.ActiveTab.ChoosedItem != draggedItem && this.ActiveTab.Items.Contains(draggedItem)) {
 					this.ActiveTab.ChoosedItem = draggedItem;
 				}
-				return new System.Windows.DataObject(draggedItem.Tag);
+				
+				if (draggedItem.Tag != null) {
+					return new System.Windows.DataObject(draggedItem.Tag);
+				}
+				else {
+					return new System.Windows.DataObject();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
As you can see I fixed the issue in 4.x branch. I assume you'll merge it up to master, or should I make another pull request to master?
