### PR TITLE
CodeCoverage again

### DIFF
--- a/src/AddIns/Analysis/CodeCoverage/Project/Src/CodeCoverageStringTextSource.cs
+++ b/src/AddIns/Analysis/CodeCoverage/Project/Src/CodeCoverageStringTextSource.cs
@@ -25,7 +25,7 @@ namespace ICSharpCode.CodeCoverage
             this.textSource = source;
 
             lineInfo line;
-            List<lineInfo> lineInfoList = new List<lineInfo>();
+            var lineInfoList = new List<lineInfo>();
             int offset = 0;
             int counter = 0;
             bool newLine = false;
@@ -95,7 +95,7 @@ namespace ICSharpCode.CodeCoverage
         /// <returns></returns>
         public string GetText(int Line, int Column, int EndLine, int EndColumn) {
 
-            StringBuilder text = new StringBuilder();
+            var text = new StringBuilder();
             string line;
             bool argOutOfRange;
 
@@ -193,7 +193,7 @@ namespace ICSharpCode.CodeCoverage
                 int remains = 0;
                 int repeat = 0;
                 char prevChar = char.MinValue;
-                StringBuilder indented = new StringBuilder();
+                var indented = new StringBuilder();
                 foreach ( char currChar in ToIndent ) {
                     if ( currChar == '\t' ) {
                         remains = counter % TabSize;


### PR DESCRIPTION
1) Removed CodeCoverageStringTextSource debug assertions/failures.
Why? 
Running SD5 in debug mode large number of assertions is revealed.
Why?
When using CodeContract ContractClass/ContractClassFor attributes,
ccrewrite inserts in "ContractClass" attributed class/interface SequencePoints from "ContractClassFor" attributed class. If "ContractClassFor" class is in another file, CodeCoverageStringTextSource.GetText(..) receives invalid line/column/endline/endcolumn arguments that fails or do not exists in file containing "ContractClass" attributed class/interface.
Why?
Afaik, cannot avoid invalid requests, because to filter them out, first need GetText() for all SequencePoints.

2) CodeCoverageMethodElement.cs changes & refactoring 
Why?
While trying to fix 1), in some rare cases SequencePoints are omitted.

3) I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
