### PR TITLE
CodeQuality: In report footer, add separation between report folder and report name

### DIFF
--- a/src/AddIns/Analysis/CodeQuality/Reporting/DependencyReport - Kopie.srd
+++ b/src/AddIns/Analysis/CodeQuality/Reporting/DependencyReport - Kopie.srd
@@ -265,7 +265,7 @@
                     <CanGrow>False</CanGrow>
                     <CanShrink>False</CanShrink>
                     <RTL>No</RTL>
-                    <Text>= Globals!ReportFolder + Globals!ReportName</Text>
+                    <Text>= Globals!ReportFolder + ' - ' + Globals!ReportName</Text>
                     <DrawBorder>False</DrawBorder>
                     <FrameColor>Black</FrameColor>
                     <ForeColor>ControlText</ForeColor>

--- a/src/AddIns/Analysis/CodeQuality/Reporting/DependencyReport.srd
+++ b/src/AddIns/Analysis/CodeQuality/Reporting/DependencyReport.srd
@@ -254,7 +254,7 @@
                     <CanGrow>False</CanGrow>
                     <CanShrink>False</CanShrink>
                     <RTL>No</RTL>
-                    <Text>= Globals!ReportFolder + Globals!ReportName</Text>
+                    <Text>= Globals!ReportFolder + ' - ' + Globals!ReportName</Text>
                     <DrawBorder>False</DrawBorder>
                     <FrameColor>Black</FrameColor>
                     <ForeColor>ControlText</ForeColor>

--- a/src/AddIns/Analysis/CodeQuality/Reporting/Overviewreport.srd
+++ b/src/AddIns/Analysis/CodeQuality/Reporting/Overviewreport.srd
@@ -440,7 +440,7 @@
                     <CanGrow>False</CanGrow>
                     <CanShrink>False</CanShrink>
                     <RTL>No</RTL>
-                    <Text>= Globals!ReportFolder +  Globals!ReportName</Text>
+                    <Text>= Globals!ReportFolder + ' - ' + Globals!ReportName</Text>
                     <DrawBorder>False</DrawBorder>
                     <FrameColor>Black</FrameColor>
                     <ForeColor>ControlText</ForeColor>


### PR DESCRIPTION
Old one shows `D:\SharpDevelop\binOverview` in left footer.
I fixed it with some separation `D:\SharpDevelop\bin - Overview` in left footer.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
