### PR TITLE
CodeQuality: Really check for project output assembly to prevent exception

### DIFF
--- a/src/AddIns/Analysis/CodeQuality/Gui/MainView.xaml.cs
+++ b/src/AddIns/Analysis/CodeQuality/Gui/MainView.xaml.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -72,7 +73,7 @@ namespace ICSharpCode.CodeQuality.Gui
 				return;
 			
 			string fileName = ProjectService.CurrentProject.OutputAssemblyFullPath;
-			if (string.IsNullOrEmpty(fileName))
+			if (!File.Exists(fileName))
 			{
 				MessageBox.Show("Project output assembly not found! Please build it first!");
 				return;


### PR DESCRIPTION
Now it checks for existence of project output assembly and show the message box.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
