### PR TITLE
Add "Browse Project" and "Browse Solution" buttons

### DIFF
--- a/data/resources/StringResources.resx
+++ b/data/resources/StringResources.resx
@@ -8145,4 +8145,13 @@ Error while starting:
     <value>This resource is not being used. Its purpose is to test the translation database and has 
 a line break</value>
   </data>
+  <data name="Dialog.SelectReferenceDialog.BrowseLastButton" xml:space="preserve">
+    <value>&amp;Browse Last...</value>
+  </data>
+  <data name="Dialog.SelectReferenceDialog.BrowseProjectButton" xml:space="preserve">
+    <value>Browse &amp;Project...</value>
+  </data>
+  <data name="Dialog.SelectReferenceDialog.BrowseSolutionButton" xml:space="preserve">
+    <value>Browse &amp;Solution...</value>
+  </data>
 </root>

--- a/src/Main/Base/Project/Src/Gui/Dialogs/ReferenceDialog/AssemblyReferencePanel.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/ReferenceDialog/AssemblyReferencePanel.cs
@@ -28,25 +28,54 @@ namespace ICSharpCode.SharpDevelop.Gui
 	public class AssemblyReferencePanel : Panel, IReferencePanel
 	{
 		ISelectReferenceDialog selectDialog;
+		Button browseButton;
+		Button browseProjectButton;
+		Button browseSolutionButton;
 		
 		public AssemblyReferencePanel(ISelectReferenceDialog selectDialog)
 		{
 			this.selectDialog = selectDialog;
+			AutoSize = true;
 			
-			Button browseButton   = new Button();
+			browseButton   = new Button();
 			browseButton.Location = new Point(10, 10);
 			browseButton.Name = "browseButton"; // requested by HP for UI automation purposes
+			browseButton.Size = new Size(120, 23);
 			
-			browseButton.Text     = StringParser.Parse("${res:Global.BrowseButtonText}");
+			browseButton.Text     = StringParser.Parse("${res:Dialog.SelectReferenceDialog.BrowseLastButton}");
 			browseButton.Click   += new EventHandler(SelectReferenceDialog);
 			browseButton.FlatStyle = FlatStyle.System;
 			Controls.Add(browseButton);
+
+			browseProjectButton   = new Button();
+			browseProjectButton.Location = new Point(150, 10);
+			browseProjectButton.Name = "browseProjectButton"; // requested by HP for UI automation purposes
+			browseProjectButton.Size = new Size(120, 23);
+
+			browseProjectButton.Text     = StringParser.Parse("${res:Dialog.SelectReferenceDialog.BrowseProjectButton}");
+			browseProjectButton.Click   += new EventHandler(SelectReferenceDialog);
+			browseProjectButton.FlatStyle = FlatStyle.System;
+			Controls.Add(browseProjectButton);
+
+			browseSolutionButton   = new Button();
+			browseSolutionButton.Location = new Point(290, 10);
+			browseSolutionButton.Name = "browseSolutionButton"; // requested by HP for UI automation purposes
+			browseSolutionButton.Size = new Size(120, 23);
+
+			browseSolutionButton.Text     = StringParser.Parse("${res:Dialog.SelectReferenceDialog.BrowseSolutionButton}");
+			browseSolutionButton.Click   += new EventHandler(SelectReferenceDialog);
+			browseSolutionButton.FlatStyle = FlatStyle.System;
+			Controls.Add(browseSolutionButton);
 		}
 		
 		void SelectReferenceDialog(object sender, EventArgs e)
 		{
 			using (OpenFileDialog fdiag  = new OpenFileDialog()) {
 				fdiag.AddExtension    = true;
+				fdiag.InitialDirectory = 
+					sender == browseProjectButton ? selectDialog.ConfigureProject.Directory.ToString()
+					: sender == browseSolutionButton ? selectDialog.ConfigureProject.ParentSolution.Directory.ToString()
+					: "";
 				
 				fdiag.Filter = StringParser.Parse("${res:SharpDevelop.FileFilter.AssemblyFiles}|*.dll;*.exe|${res:SharpDevelop.FileFilter.AllFiles}|*.*");
 				fdiag.Multiselect     = true;


### PR DESCRIPTION
This facilitates choosing more DLL from project's directory or solution's directory.
The original button renamed as "Browse Last" and it remains opening last directory chosen.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
