### PR TITLE
Fixes issue #402: NullReferenceException when creating new WPF application project

### DIFF
--- a/src/AddIns/BackendBindings/CSharpBinding/Project/Src/Project/CSharpProject.cs
+++ b/src/AddIns/BackendBindings/CSharpBinding/Project/Src/Project/CSharpProject.cs
@@ -142,7 +142,7 @@ namespace CSharpBinding
 		public override void Save(string fileName)
 		{
 			// Save project extensions
-			if (extensionProperties.IsDirty) {
+			if (extensionProperties != null && extensionProperties.IsDirty) {
 				var propertiesXElement = extensionProperties.Save();
 				SaveProjectExtensions(ExtensionPropertiesName, propertiesXElement);
 				extensionProperties.IsDirty = false;


### PR DESCRIPTION
Fixes issue #402

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
