### PR TITLE
Fixes #105: Toggling multiple block comments

### DIFF
--- a/src/Main/Base/Project/Src/Editor/IFormattingStrategy.cs
+++ b/src/Main/Base/Project/Src/Editor/IFormattingStrategy.cs
@@ -143,8 +143,21 @@ namespace ICSharpCode.SharpDevelop.Editor
 				BlockCommentRegion region = FindSelectedCommentRegion(editor, blockStart, blockEnd);
 				
 				if (region != null) {
-					editor.Document.Remove(region.EndOffset, region.CommentEnd.Length);
-					editor.Document.Remove(region.StartOffset, region.CommentStart.Length);
+					do {
+						editor.Document.Remove(region.EndOffset, region.CommentEnd.Length);
+						editor.Document.Remove(region.StartOffset, region.CommentStart.Length);
+						
+						int selectionStart = region.EndOffset;
+						int selectionLength = editor.SelectionLength - (region.EndOffset - editor.SelectionStart);
+						
+						if(selectionLength > 0) {
+							editor.Select(region.EndOffset, selectionLength);
+							region = FindSelectedCommentRegion(editor, blockStart, blockEnd);
+						} else {
+							region = null; 
+						}
+					} while(region != null);
+				
 				} else {
 					editor.Document.Insert(endOffset, blockEnd);
 					editor.Document.Insert(startOffset, blockStart);


### PR DESCRIPTION
One of the older small issues on the issue list, if it is still relevant (and if this change is OK). Uncommenting XML multiple comment blocks.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
