### PR TITLE
Correct 32-bit / AnyCPU project detection for unit test

### DIFF
--- a/src/AddIns/Analysis/UnitTesting/NUnit/NUnitConsoleApplication.cs
+++ b/src/AddIns/Analysis/UnitTesting/NUnit/NUnitConsoleApplication.cs
@@ -254,7 +254,7 @@ namespace ICSharpCode.UnitTesting
 			MSBuildBasedProject msbuildProject = project as MSBuildBasedProject;
 			if (msbuildProject != null) {
 				string platformTarget = msbuildProject.GetEvaluatedProperty("PlatformTarget");
-				return String.Equals(platformTarget, "x86", StringComparison.OrdinalIgnoreCase)
+				return string.IsNullOrEmpty(platformTarget) || String.Equals(platformTarget, "x86", StringComparison.OrdinalIgnoreCase)
 					|| String.Equals(platformTarget, "AnyCPU", StringComparison.OrdinalIgnoreCase);
 			}
 			return false;


### PR DESCRIPTION
Correct 32-bit / AnyCPU project detection for unit test.
Empty string means AnyCPU.
