### PR TITLE
AvalonEdit: Add Padding for Line Height

### DIFF
--- a/src/Libraries/AvalonEdit/ICSharpCode.AvalonEdit/Rendering/TextView.cs
+++ b/src/Libraries/AvalonEdit/ICSharpCode.AvalonEdit/Rendering/TextView.cs
@@ -249,41 +249,26 @@ namespace ICSharpCode.AvalonEdit.Rendering
 
 		#region Line Height Properties
 		/// <summary>
-		/// Minimum line height, in WPF Pixel units
+		/// Padding around lines, in WPF Pixel units
 		/// </summary>
-		public static readonly DependencyProperty MinLineHeightProperty =
-			DependencyProperty.Register("MinLineHeight", typeof(double?), typeof(TextView),
-						    new FrameworkPropertyMetadata(OnLineHeightChanged));
-		
-		/// <summary>
-		/// Minimum line height, in WPF Pixel units
-		/// </summary>
-		public static readonly DependencyProperty MaxLineHeightProperty =
-			DependencyProperty.Register("MaxLineHeight", typeof(double?), typeof(TextView),
-						    new FrameworkPropertyMetadata(OnLineHeightChanged));
+		public static readonly DependencyProperty ExtraLineHeightProperty =
+			DependencyProperty.Register("ExtraLineHeight", typeof(double), typeof(TextView),
+						    new FrameworkPropertyMetadata(OnExtraLineHeightChanged));
 
 		/// <summary>
 		/// Gets/Sets the options used by the text editor.
 		/// </summary>
-		public double? MinLineHeight {
-			get { return (double?)GetValue(MinLineHeightProperty); }
-			set { SetValue(MinLineHeightProperty, value); }
-		}
-		
-		/// <summary>
-		/// Gets/Sets the options used by the text editor.
-		/// </summary>
-		public double? MaxLineHeight {
-			get { return (double?)GetValue(MaxLineHeightProperty); }
-			set { SetValue(MaxLineHeightProperty, value); }
+		public double ExtraLineHeight {
+			get { return (double)GetValue(ExtraLineHeightProperty); }
+			set { SetValue(ExtraLineHeightProperty, value); }
 		}
 
-		static void OnLineHeightChanged(DependencyObject dp, DependencyPropertyChangedEventArgs e)
+		static void OnExtraLineHeightChanged(DependencyObject dp, DependencyPropertyChangedEventArgs e)
 		{
-			((TextView)dp).OnLineHeightChanged((double)e.OldValue, (double)e.NewValue, e.Property == MaxLineHeightProperty);
+			((TextView)dp).OnExtraLineHeightChanged((double)e.OldValue, (double)e.NewValue);
 		}
 		
-		void OnLineHeightChanged(double? oldValue, double? newValue, bool minOrMaxProperty)
+		void OnExtraLineHeightChanged(double oldValue, double newValue)
 		{
 			Redraw();
 		}

--- a/src/Libraries/AvalonEdit/ICSharpCode.AvalonEdit/Rendering/VisualLine.cs
+++ b/src/Libraries/AvalonEdit/ICSharpCode.AvalonEdit/Rendering/VisualLine.cs
@@ -283,11 +283,7 @@ namespace ICSharpCode.AvalonEdit.Rendering
 			foreach (TextLine line in textLines)
 				Height += line.Height;
 
-			if (textView.MinLineHeight.HasValue)
-				Height = Math.Min(Height, textView.MinLineHeight.Value);
-
-			if (textView.MaxLineHeight.HasValue)
-				Height = Math.Max(Height, textView.MaxLineHeight.Value);
+			Height += textView.ExtraLineHeight;
 		}
 		
 		/// <summary>


### PR DESCRIPTION
This PR adds support to AvalonEdit for altering the line height via a new Padding property on TextView
## TODO:
- [x] Switch Min/Max to simple padding, since Min / Max falls over in the wrapped line case
- [ ] Fix rendering to actually put lines in the right place
- [ ] Handle notifying margin handlers of padding changes
