### PR TITLE
UnitTestNode should subscribe test events on create

### DIFF
--- a/src/AddIns/Analysis/UnitTesting/Pad/UnitTestNode.cs
+++ b/src/AddIns/Analysis/UnitTesting/Pad/UnitTestNode.cs
@@ -37,6 +37,10 @@ namespace ICSharpCode.UnitTesting
 			if (test == null)
 				throw new ArgumentNullException("test");
 			this.test = test;
+			if (IsVisible) {
+				test.DisplayNameChanged += test_NameChanged;
+				test.ResultChanged += test_ResultChanged;
+			}
 		}
 		
 		protected override void OnIsVisibleChanged()


### PR DESCRIPTION
Fix no result color displayed on tree node if do not perform expand-collapse-expand actions.

Steps to reproduce:
1. Open an NUnit test project
2. Click `Run all tests` button
3. Tests run with result
4. Result colors unchanged on tree nodes

If you expand the tree nodes, then collapse them and expand again,
run the tests, result colors will be changed on tree nodes.
