### PR TITLE
Should append "(Error)" instead of "(Readonly)" if failed to load project

### DIFF
--- a/src/Main/Base/Project/Src/Gui/Pads/ProjectBrowser/TreeNodes/ProjectNode.cs
+++ b/src/Main/Base/Project/Src/Gui/Pads/ProjectBrowser/TreeNodes/ProjectNode.cs
@@ -65,20 +65,21 @@ namespace ICSharpCode.SharpDevelop.Project
 			this.project = project;
 			
 			Text = project.Name;
-			if (project.IsReadOnly) {
-				Text += StringParser.Parse(" (${res:Global.ReadOnly})");
-			}
-			
 			autoClearNodes = false;
 			
 			if (project is MissingProject) {
 				OpenedImage = ClosedImage = "ProjectBrowser.MissingProject";
 				this.ContextmenuAddinTreePath = "/SharpDevelop/Pads/ProjectBrowser/ContextMenu/MissingProjectNode";
+				Text += StringParser.Parse(" (${res:Global.ErrorText})");
 			} else if (project is ErrorProject) {
 				OpenedImage = ClosedImage = "ProjectBrowser.ProjectWarning";
 				this.ContextmenuAddinTreePath = "/SharpDevelop/Pads/ProjectBrowser/ContextMenu/UnknownProjectNode";
+				Text += StringParser.Parse(" (${res:Global.ErrorText})");
 			} else {
 				OpenedImage = ClosedImage = IconService.GetImageForProjectType(project.Language);
+				if (project.IsReadOnly) {
+					Text += StringParser.Parse(" (${res:Global.ReadOnly})");
+				}
 			}
 			Tag = project;
 			


### PR DESCRIPTION
Should append "(Error)" instead of "(Readonly)" if failed to load project

![sharpdeveloploadprojectfailed](https://cloud.githubusercontent.com/assets/791115/2631077/354cfb94-be54-11e3-8f0e-a0e62c8f53ef.png)

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
