### PR TITLE
WinForms Designer should not modify class fields of generic types outside designer file

### DIFF
--- a/src/AddIns/BackendBindings/CSharpBinding/Project/Src/FormsDesigner/CSharpDesignerGenerator.cs
+++ b/src/AddIns/BackendBindings/CSharpBinding/Project/Src/FormsDesigner/CSharpDesignerGenerator.cs
@@ -284,7 +284,7 @@ namespace CSharpBinding.FormsDesigner
 				return false;
 			}
 			
-			return oldType.ReflectionName != newType.BaseType;
+			return oldType.GetDefinition().ReflectionName != newType.BaseType;
 		}
 		
 		string GenerateField(CodeMemberField newField)


### PR DESCRIPTION
Here is the sample code:

```
using System;
using System.Collections.Generic;
using System.Windows.Forms;

namespace WinForm1
{
    public partial class Form1 : Form
    {
        string simple = "abc";
        List<string> myList = new List<string>();

        public Form1()
        {
            InitializeComponent();
        }
    }
}
```

Should not become

```
using System;
using System.Collections.Generic;
using System.Windows.Forms;

namespace WinForm1
{
    public partial class Form1 : Form
    {
        string simple = "abc";
        System.Collections.Generic.List<string> myList;

        public Form1()
        {
            InitializeComponent();
        }
    }
}
```
