### PR TITLE
Add trailing newline when generating InitializeComponents()

### DIFF
--- a/src/AddIns/BackendBindings/CSharpBinding/Project/Src/FormsDesigner/CSharpDesignerGenerator.cs
+++ b/src/AddIns/BackendBindings/CSharpBinding/Project/Src/FormsDesigner/CSharpDesignerGenerator.cs
@@ -182,7 +182,7 @@ namespace CSharpBinding.FormsDesigner
 			
 			string newline = DocumentUtilities.GetLineTerminator(script.OriginalDocument, bodyRegion.BeginLine);
 			string indentation = DocumentUtilities.GetIndentation(script.OriginalDocument, bodyRegion.BeginLine);
-			string code = "{" + newline + GenerateInitializeComponents(codeMethod, indentation, newline) + indentation + "}";
+			string code = "{" + newline + GenerateInitializeComponents(codeMethod, indentation, newline) + newline + indentation + "}";
 			
 			int startOffset = script.GetCurrentOffset(bodyRegion.Begin);
 			int endOffset = script.GetCurrentOffset(bodyRegion.End);


### PR DESCRIPTION
This matches VS behavior
