### PR TITLE
Added TextValue property to expose the xaml string value for a property.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Xaml/XamlModelProperty.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Xaml/XamlModelProperty.cs
@@ -121,6 +121,18 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 			}
 		}
 		
+		public override string TextValue
+		{
+			get {
+				var xamlTextValue = _property.PropertyValue as XamlTextValue;
+				if (xamlTextValue != null) {
+					return xamlTextValue.Text;
+				}
+
+				return null;
+			}
+		}
+		
 		// There may be multiple XamlModelProperty instances for the same property,
 		// so this class may not have any mutable fields / events - instead,
 		// we forward all event handlers to the XamlProperty.

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Tests/Designer/ModelTests.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Tests/Designer/ModelTests.cs
@@ -693,6 +693,29 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context, "xmlns:Controls0=\"clr-namespace:System;assembly=mscorlib\"");
 			AssertLog("");
 		}
+		
+		[Test]
+		public void TestTextValue()
+		{
+			// An invalid path (in this case containing a question mark), or a path to a file that does not exist, will give the same result.
+			// It will cause the typeconverter to fail and no value can be get from neither ValueOnInstance nor Value from the Image.Source DesignItemProperty.
+			// TextValue was added to have a way of getting the xaml value.
+			string sourceTextValue = "file:///C:/Folder/image?.bmp";
+			
+			string xaml = "<Image Source=\"" + sourceTextValue + "\" />";
+			DesignItem image = CreateCanvasContext(xaml);
+			
+			var sourceProp = image.Properties[Image.SourceProperty];
+			
+			Assert.IsNull(sourceProp.ValueOnInstance);
+			Assert.IsNull(sourceProp.Value);
+			Assert.IsNotNull(sourceProp.TextValue);
+			Assert.AreEqual(sourceTextValue, sourceProp.TextValue);
+			
+			string expectedXaml = xaml;
+			AssertCanvasDesignerOutput(expectedXaml, image.Context);
+			AssertLog("");
+		}
 	}
 	
 	public class MyMultiConverter : IMultiValueConverter

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DesignItemProperty.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DesignItemProperty.cs
@@ -82,6 +82,12 @@ namespace ICSharpCode.WpfDesign
 		public abstract DesignItem Value { get; }
 		
 		/// <summary>
+		/// Gets the string value of the property. This property returns null if the value is not set,
+		/// or if the value is set to a non-primitive value (i.e. represented by a <see cref="DesignItem"/>, accessible through <see cref="Value"/> property).
+		/// </summary>
+		public abstract string TextValue { get; }
+		
+		/// <summary>
 		/// Is raised when the value of the property changes (by calling <see cref="SetValue"/> or <see cref="Reset"/>).
 		/// </summary>
 		public abstract event EventHandler ValueChanged;


### PR DESCRIPTION
If there is another way for me to get the value for a property where the type converter fails please let me know, as it might make this fix unnecessary.

My first thought was to add a property with the signature "object PrimitiveValue", but is it even remotely possible that there will be other primitives than string/text represented?
If this feels like a better option let me know and I'll make another pull request.
