### PR TITLE
Fix for bug introduced with new snapline behaviour

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/SnaplinePlacementBehavior.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/SnaplinePlacementBehavior.cs
@@ -183,7 +183,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					yield return designItem;
 					if (designItem.ContentProperty.Value != null) {
 						yield return designItem.ContentProperty.Value;
-						designItem = designItem.ContentProperty.Value;
+						designItem = ExtendedItem; //set designitem back to current control after yield
 					}
 				}
 			}


### PR DESCRIPTION
As long as the document follows the following pattern (as a "new window" in SD does) the current code in SD-master works as expected.
<Window
    x:Class="test.Window1" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
    Title="test"
    Height="800"
    Width="600">
    <Grid>
    </Grid>
</Window>

But if we introduce another setup, for example the following, it does not work anymore (but did work before the snapline changes was merged).
<Window
    x:Class="test.Window1" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
    Title="test"
    Height="800"
    Width="600">
    <AdornerDecorator>
        <Grid>
        </Grid>
    </AdornerDecorator>
</Window>

This fix make it work as expected. I have discussed this fix with jogibear9988 that introduced the new snapline features and he has approved this fix.
