### PR TITLE
Correctly handle ServiceCreatorCallback in GetFutureService

### DIFF
--- a/src/Main/Base/Project/Util/SharpDevelopServiceContainer.cs
+++ b/src/Main/Base/Project/Util/SharpDevelopServiceContainer.cs
@@ -161,9 +161,8 @@ namespace ICSharpCode.SharpDevelop
 		{
 			Type serviceType = typeof(T);
 			lock (services) {
-				object instance;
-				if (services.TryGetValue(serviceType, out instance)) {
-					return Task.FromResult((T)instance);
+				if (services.ContainsKey(serviceType)) {
+					return Task.FromResult((T)GetService(serviceType));
 				} else {
 					object taskCompletionSource;
 					if (taskCompletionSources.TryGetValue(serviceType, out taskCompletionSource)) {


### PR DESCRIPTION
GetFutureService in SharpDevelopServiceContainer does not correctly handle lazy service instantiation like GetService does.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.
