### PR TITLE
Fixed bug where resizing right and bottom edges on controls did not snap properly.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/SnaplinePlacementBehavior.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/SnaplinePlacementBehavior.cs
@@ -121,7 +121,6 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					} else {
 						bounds.Height = Math.Max(0, bounds.Height + delta);
 					}
-					bounds.Height = Math.Max(0, bounds.Height - delta);
 					info.Bounds = bounds;
 				} else {
 					foreach (var item in operation.PlacedItems) {
@@ -145,7 +144,6 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					} else {
 						bounds.Width = Math.Max(0, bounds.Width + delta);
 					}
-					bounds.Width = Math.Max(0, bounds.Width - delta);
 					info.Bounds = bounds;
 				} else {
 					foreach (var item in operation.PlacedItems) {


### PR DESCRIPTION
The bug was introduced in a combination of code modification and merge conflict resolved incorrectly.
For details see history for SnaplinePlacementBehavior.cs, in particular the following:
https://github.com/icsharpcode/SharpDevelop/commit/c825585043caa94fe741a7970728c160fa48fed1
https://github.com/icsharpcode/SharpDevelop/commit/b43ed8ab81079ab2298ac3ad52f1d60e7395cfe8
