### PR TITLE
Modified precision for element positioning and boundaries to use 0 decimals.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/PlacementInformation.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/PlacementInformation.cs
@@ -28,9 +28,9 @@ namespace ICSharpCode.WpfDesign
 	{
 		/// <summary>
 		/// The designer rounds bounds to this number of digits to avoid floating point errors.
-		/// Value: 1
+		/// Value: 0
 		/// </summary>
-		public const int BoundsPrecision = 1;
+		public const int BoundsPrecision = 0;
 		
 		Rect originalBounds, bounds;
 		readonly DesignItem item;


### PR DESCRIPTION
Using parts of a pixel as measure does more harm than good, and both Blend and Visual Studio uses whole pixels for placement and resizing in their editor.
