### PR TITLE
StackPanel no longer removes properties that are used in the panel.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/StackPanelPlacementSupport.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/StackPanelPlacementSupport.cs
@@ -89,11 +89,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		public override void EnterContainer(PlacementOperation operation)
 		{
 			base.EnterContainer(operation);
-			foreach (var info in operation.PlacedItems) {
-				info.Item.Properties[FrameworkElement.MarginProperty].Reset();
-				info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].Reset();
-				info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].Reset();
-			}
+			
 			_rectangle.Visibility = Visibility.Visible;
 		}
 


### PR DESCRIPTION
If copying an element in a StackPanel and then pasting it in the same or another StackPanel you want to get Margin and alignment properties with you, only annoying if it resets them. Blend and Visual Studio also keeps the properties in this scenario.
