### PR TITLE
Drop handler is now giving correct feedback to drag source.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Services/CreateComponentTool.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Services/CreateComponentTool.cs
@@ -124,8 +124,6 @@ namespace ICSharpCode.WpfDesign.Designer.Services
 					moveLogic = null;
 					changeGroup.Commit();
 
-					// Return allowed effects to drag source to signal that the drop was successful.
-					e.Effects = e.Effects;
 					e.Handled = true;
 				}
 			} catch (Exception x) {


### PR DESCRIPTION
Without this change, the drag source will always get "None" as result, probably set by another handler that kicked in because e.Handled was not set to true.

For more information see: http://msdn.microsoft.com/en-us/library/system.windows.dragdrop.drop%28v=vs.110%29.aspx

In particular this:
To notify the drag source of the effect of the drop, such as a copy or move, set the DragEventArgs.Effects property in the Drop event handler. The value of this property is the return value of the DoDragDrop method that initiated the drag-and-drop operation. If the value that is returned does not match one of the allowedEffects specified in the call to DoDragDrop, the drag-and-drop operation is not performed.
