### PR TITLE
Update active solution configuration in Solution Configurator Editor

### DIFF
--- a/src/Main/SharpDevelop/Project/Configuration/SolutionConfigurationEditor.cs
+++ b/src/Main/SharpDevelop/Project/Configuration/SolutionConfigurationEditor.cs
@@ -19,12 +19,12 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 
 using ICSharpCode.Core;
 using ICSharpCode.SharpDevelop.Project;
-using System.ComponentModel;
 
 namespace ICSharpCode.SharpDevelop.Project
 {


### PR DESCRIPTION
Small change for Solution Configurator editor: now active solution configuration changes after it was changed in configuration editor. For VS users it is the most expected behavior.
The problem was mentioned in issue https://github.com/icsharpcode/SharpDevelop/issues/250.

_I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License._

Regards,
Oleg
