### PR TITLE
Added null-check necessary when a markup extension without a wrapper is ...

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Tests/Designer/ModelTests.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Tests/Designer/ModelTests.cs
@@ -690,6 +690,36 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 		}
 		
 		[Test]
+		public void AddMarkupExtensionWithoutWrapperToCollection()
+		{
+			DesignItem textBox = CreateCanvasContext("<TextBox/>");
+			
+			DesignItem multiBindingItem = textBox.Context.Services.Component.RegisterComponentForDesigner(new System.Windows.Data.MultiBinding());
+			multiBindingItem.Properties["Converter"].SetValue(new ICSharpCode.WpfDesign.Tests.XamlDom.MyMultiConverter());
+			DesignItemProperty bindingsProp = multiBindingItem.ContentProperty;
+			
+			// MyBindingExtension is a markup extension that will not use a wrapper. 
+			DesignItem myBindingExtension = textBox.Context.Services.Component.RegisterComponentForDesigner(new ICSharpCode.WpfDesign.Tests.XamlDom.MyBindingExtension());
+			
+			// Adding it to MultiBinding "Bindings" collection.
+			bindingsProp.CollectionElements.Add(myBindingExtension);
+			
+			textBox.ContentProperty.SetValue(multiBindingItem);
+			
+			const string expectedXaml = "<TextBox>\n" +
+									    "  <MultiBinding>\n" +
+									    "    <MultiBinding.Converter>\n" +
+									    "      <Controls0:MyMultiConverter />\n" +
+									    "    </MultiBinding.Converter>\n" +
+									    "    <Controls0:MyBindingExtension />\n" +
+									    "  </MultiBinding>\n" +
+										"</TextBox>";
+			
+			AssertCanvasDesignerOutput(expectedXaml, textBox.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
+			AssertLog("");
+		}
+		
+		[Test]
 		public void AddBrushAsResource()
 		{
 			DesignItem checkBox = CreateCanvasContext("<CheckBox/>");

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Tests/XamlDom/MarkupExtensionTests.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Tests/XamlDom/MarkupExtensionTests.cs
@@ -133,6 +133,7 @@ namespace ICSharpCode.WpfDesign.Tests.XamlDom
         <t:MyMultiConverter />
       </MultiBinding.Converter>
       <Binding Path=""SomeProperty"" />
+      <t:MyBindingExtension />
     </MultiBinding>
   </TextBox>
 </Window>";
@@ -157,7 +158,7 @@ namespace ICSharpCode.WpfDesign.Tests.XamlDom
 			var converter = expr.ParentMultiBinding.Converter as MyMultiConverter;
 			Assert.IsNotNull(converter);
 			
-			Assert.AreEqual(expr.ParentMultiBinding.Bindings.Count, 1);
+			Assert.AreEqual(expr.ParentMultiBinding.Bindings.Count, 2);
 		}
 		
 		[Test]
@@ -266,5 +267,24 @@ namespace ICSharpCode.WpfDesign.Tests.XamlDom
 		}
 		#endregion
 		
+	}
+	
+	public class MyBindingExtension : MarkupExtension
+	{
+		readonly Binding binding = new Binding();
+		
+		public MyBindingExtension()
+		{
+			var exampleClass = new ExampleClass();
+			exampleClass.StringProp = "Test";
+			
+			binding.Source = exampleClass;
+			binding.Path = new PropertyPath("StringProp");
+		}
+
+		public override object ProvideValue(IServiceProvider serviceProvider)
+		{
+			return binding.ProvideValue(serviceProvider);
+		}
 	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
@@ -583,7 +583,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			if (wrapper != null) {
 				return wrapper.ProvideValue();
 			}
-			if (this.ParentObject.ElementType == typeof (Setter) && this.ElementType == typeof(DynamicResourceExtension))
+			if (this.ParentObject != null && this.ParentObject.ElementType == typeof (Setter) && this.ElementType == typeof(DynamicResourceExtension))
 				return Instance;
 			return (Instance as MarkupExtension).ProvideValue(ServiceProvider);
 		}


### PR DESCRIPTION
...added to a collection.
