### PR TITLE
MarkupExtensionWrapper is now public to make it possible to make wrapper...

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/MarkupExtensionWrapper.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/MarkupExtensionWrapper.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) 2014 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Windows.Markup;
+
+namespace ICSharpCode.WpfDesign.XamlDom
+{
+	/// <summary>
+	/// A wrapper for markup extensions if custom behavior of <see cref="System.Windows.Markup.MarkupExtension.ProvideValue"/> is needed in the designer.
+	/// </summary>
+	public abstract class MarkupExtensionWrapper
+	{
+		/// <summary>
+		/// Initializes a new instance.
+		/// </summary>
+		/// <param name="xamlObject">The <see cref="XamlObject"/> object that represents the markup extension.</param>
+		protected MarkupExtensionWrapper(XamlObject xamlObject)
+		{
+			if (xamlObject == null) {
+				throw new ArgumentNullException("xamlObject");
+			}
+			
+			XamlObject = xamlObject;
+		}
+		
+		/// <summary>
+		/// Gets the <see cref="XamlObject"/> object that represents the markup extension.
+		/// </summary>
+		public XamlObject XamlObject { get; private set; }
+		
+		/// <summary>
+		/// Returns an object that should be used as the value of the target property in the designer. 
+		/// </summary>
+		/// <returns>An object that should be used as the value of the target property in the designer.</returns>
+		public abstract object ProvideValue();
+		
+		static readonly Dictionary<Type, Type> s_MarkupExtensionWrappers = new Dictionary<Type, Type>();
+
+		/// <summary>
+		/// Registers a markup extension wrapper.
+		/// </summary>
+		/// <param name="markupExtensionType">The type of the markup extension.</param>
+		/// <param name="markupExtensionWrapperType">The type of the markup extension wrapper.</param>
+		public static void RegisterMarkupExtensionWrapper(Type markupExtensionType, Type markupExtensionWrapperType)
+		{
+			if (markupExtensionType == null) {
+				throw new ArgumentNullException("markupExtensionType");
+			}
+			
+			if (!markupExtensionType.IsSubclassOf(typeof(MarkupExtension))) {
+				throw new ArgumentException("The specified type must derive from MarkupExtension.", "markupExtensionType");
+			}
+			
+			if (markupExtensionWrapperType == null) {
+				throw new ArgumentNullException("markupExtensionWrapperType");
+			}
+			
+			if (!markupExtensionWrapperType.IsSubclassOf(typeof(MarkupExtensionWrapper))) {
+				throw new ArgumentException("The specified type must derive from MarkupExtensionWrapper.", "markupExtensionWrapperType");
+			}
+			
+			s_MarkupExtensionWrappers.Add(markupExtensionType, markupExtensionWrapperType);
+		}
+		
+		internal static MarkupExtensionWrapper CreateWrapper(Type markupExtensionWrapperType, XamlObject xamlObject)
+		{
+			return Activator.CreateInstance(markupExtensionWrapperType, xamlObject) as MarkupExtensionWrapper;
+		}
+		
+		internal static MarkupExtensionWrapper TryCreateWrapper(Type markupExtensionType, XamlObject xamlObject)
+		{
+			Type markupExtensionWrapperType;
+			if (s_MarkupExtensionWrappers.TryGetValue(markupExtensionType, out markupExtensionWrapperType)) {
+				return CreateWrapper(markupExtensionWrapperType, xamlObject);
+			}
+			
+			return null;
+		}
+	}
+}

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/MarkupExtensionWrapperAttribute.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/MarkupExtensionWrapperAttribute.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2014 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+ 
+using System;
+
+namespace ICSharpCode.WpfDesign.XamlDom
+{
+	/// <summary>
+	/// Apply this to markup extensions that needs custom behavior of <see cref="System.Windows.Markup.MarkupExtension.ProvideValue"/> in the designer.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+	public class MarkupExtensionWrapperAttribute : Attribute
+	{
+		/// <summary>
+		/// Initializes a new instance of <see cref="MarkupExtensionWrapperAttribute"/>.
+		/// </summary>
+		/// <param name="markupExtensionWrapperType">The wrapper type.</param>
+		public MarkupExtensionWrapperAttribute(Type markupExtensionWrapperType)
+		{
+			MarkupExtensionWrapperType = markupExtensionWrapperType;
+		}
+		
+		/// <summary>
+		/// Gets the wrapper type.
+		/// </summary>
+		public Type MarkupExtensionWrapperType { get; private set; }
+	}
+}

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/WpfDesign.XamlDom.csproj
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/WpfDesign.XamlDom.csproj
@@ -75,6 +75,8 @@
     <Compile Include="MarkupCompatibilityProperties.cs" />
     <Compile Include="MarkupExtensionParser.cs" />
     <Compile Include="MarkupExtensionPrinter.cs" />
+    <Compile Include="MarkupExtensionWrapper.cs" />
+    <Compile Include="MarkupExtensionWrapperAttribute.cs" />
     <Compile Include="NameScopeHelper.cs" />
     <Compile Include="PositionXmlDocument.cs" />
     <Compile Include="TemplateHelper.cs" />

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
@@ -569,12 +569,19 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		void CreateWrapper()
 		{
 			if (Instance is BindingBase) {
-				wrapper = new BindingWrapper();
+				wrapper = new BindingWrapper(this);
 			} else if (Instance is StaticResourceExtension) {
-				wrapper = new StaticResourceWrapper();
+				wrapper = new StaticResourceWrapper(this);
 			}
-			if (wrapper != null) {
-				wrapper.XamlObject = this;
+			
+			if (wrapper == null && IsMarkupExtension) {
+				var markupExtensionWrapperAttribute = Instance.GetType().GetCustomAttributes(typeof(MarkupExtensionWrapperAttribute), false).FirstOrDefault() as MarkupExtensionWrapperAttribute;
+				if(markupExtensionWrapperAttribute != null) {
+					wrapper = MarkupExtensionWrapper.CreateWrapper(markupExtensionWrapperAttribute.MarkupExtensionWrapperType, this);
+				}
+				else {
+					wrapper = MarkupExtensionWrapper.TryCreateWrapper(Instance.GetType(), this);
+				}
 			}
 		}
 
@@ -608,14 +615,13 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		public event EventHandler NameChanged;
 	}
 
-	abstract class MarkupExtensionWrapper
-	{
-		public XamlObject XamlObject { get; set; }
-		public abstract object ProvideValue();
-	}
-
 	class BindingWrapper : MarkupExtensionWrapper
 	{
+		public BindingWrapper(XamlObject xamlObject)
+			: base(xamlObject)
+		{
+		}
+		
 		public override object ProvideValue()
 		{
 			var target = XamlObject.Instance as BindingBase;
@@ -661,6 +667,11 @@ namespace ICSharpCode.WpfDesign.XamlDom
 
 	class StaticResourceWrapper : MarkupExtensionWrapper
 	{
+		public StaticResourceWrapper(XamlObject xamlObject)
+			: base(xamlObject)
+		{
+		}
+		
 		public override object ProvideValue()
 		{
 			var target = XamlObject.Instance as StaticResourceExtension;


### PR DESCRIPTION
...s for non-standard markup extensions. Wrapper can be registered by applying MarkupExtensionWrapperAttribute or calling the static method RegisterMarkupExtensionWrapper of the MarkupExtensionWrapper class.
