### PR TITLE
Fix closing tag for exception (xml-docs)

### DIFF
--- a/src/Libraries/NRefactory/ICSharpCode.NRefactory.CSharp/Completion/CSharpCompletionEngine.cs
+++ b/src/Libraries/NRefactory/ICSharpCode.NRefactory.CSharp/Completion/CSharpCompletionEngine.cs
@@ -3629,7 +3629,7 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 			yield return factory.CreateXmlDocCompletionData(
 				"exception",
 				"Identifies the exceptions a method can throw",
-				"exception cref=\"|\"></exception"
+				"exception cref=\"|\"></exception>"
 			);
 			yield return factory.CreateXmlDocCompletionData(
 				"include",


### PR DESCRIPTION
Code completion for **exception** xml-doc element produces a wrong closing tag.