### PR TITLE
Assembly Info Editor. TextBox for assembly informational version.

### DIFF
--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfo.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfo.cs
@@ -43,7 +43,7 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 
 		public Version AssemblyFileVersion { get; set; }
 
-		public Version InformationalVersion { get; set; }
+		public string InformationalVersion { get; set; }
 
 		public Guid? Guid { get; set; }
 

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoPanel.xaml
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoPanel.xaml
@@ -1,13 +1,13 @@
 ﻿<optionPanels:ProjectOptionPanel 
 	x:Class="ICSharpCode.SharpDevelop.Gui.OptionPanels.AssemblyInfoPanel"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:core="http://icsharpcode.net/sharpdevelop/core"
-    xmlns:optionPanels="clr-namespace:ICSharpCode.SharpDevelop.Gui.OptionPanels"
-    xmlns:projectOptions="clr-namespace:ICSharpCode.SharpDevelop.Gui.Dialogs.OptionPanels.ProjectOptions"
-    mc:Ignorable="d"
+	xmlns:optionPanels="clr-namespace:ICSharpCode.SharpDevelop.Gui.OptionPanels"
+	xmlns:projectOptions="clr-namespace:ICSharpCode.SharpDevelop.Gui.Dialogs.OptionPanels.ProjectOptions"
+	mc:Ignorable="d"
 	d:DataContext="{d:DesignInstance Type={x:Type optionPanels:AssemblyInfoViewModel}}">
 	<ScrollViewer VerticalScrollBarVisibility="Auto">
 		<Grid x:Name="RootGrid">

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoPanel.xaml
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoPanel.xaml
@@ -94,7 +94,7 @@
 			<projectOptions:VersionEditor Version="{Binding AssemblyFileVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="8"/>
 
 			<Label Content="{core:Localize Dialog.ProjectOptions.AssemblyInfo.InformationalVersion}" Grid.Column="0" Grid.Row="9"/>
-			<projectOptions:VersionEditor Version="{Binding InformationalVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="9"/>
+			<TextBox Text="{Binding InformationalVersion, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="9"/>
 
 			<Label Content="{core:Localize Dialog.ProjectOptions.AssemblyInfo.GUID}" Grid.Column="0" Grid.Row="10"/>
 			<TextBox Text="{Binding Guid, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.Row="10"/>

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoProvider.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoProvider.cs
@@ -130,7 +130,7 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 							break;
 						case AssemblyInformationalVersion:
 						case AssemblyInformationalVersion + Attribute:
-							assemblyInfo.InformationalVersion = GetAttributeValueAsVersion(attribute);
+                            assemblyInfo.InformationalVersion = GetAttributeValue<string>(attribute);
 							break;
 						case Guid:
 						case Guid + Attribute:
@@ -212,7 +212,7 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, AssemblyDefaultAlias, assemblyInfo.DefaultAlias);
 			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, AssemblyVersion, assemblyInfo.AssemblyVersion, null, true);
 			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, AssemblyFileVersion, assemblyInfo.AssemblyFileVersion, null, true);
-			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, AssemblyInformationalVersion, assemblyInfo.InformationalVersion, null, true);
+			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, AssemblyInformationalVersion, assemblyInfo.InformationalVersion);
 			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, Guid, assemblyInfo.Guid, null, true);
 			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, NeutralResourcesLanguage, assemblyInfo.NeutralLanguage);
 			SetAttributeValueOrAddAttributeIfNotDefault(syntaxTree, ComVisible, assemblyInfo.ComVisible, false);

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoProvider.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoProvider.cs
@@ -130,7 +130,7 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 							break;
 						case AssemblyInformationalVersion:
 						case AssemblyInformationalVersion + Attribute:
-                            assemblyInfo.InformationalVersion = GetAttributeValue<string>(attribute);
+							assemblyInfo.InformationalVersion = GetAttributeValue<string>(attribute);
 							break;
 						case Guid:
 						case Guid + Attribute:

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoViewModel.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoViewModel.cs
@@ -104,7 +104,7 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 			set { assemblyInfo.AssemblyFileVersion = value; OnPropertyChanged(); }
 		}
 
-		public Version InformationalVersion
+		public string InformationalVersion
 		{
 			get { return assemblyInfo.InformationalVersion; }
 			set { assemblyInfo.InformationalVersion = value; OnPropertyChanged(); }


### PR DESCRIPTION
We can put any string for assembly informational version, not just "1.0.0.0" string.
Link: http://stackoverflow.com/questions/64602/what-are-differences-between-assemblyversion-assemblyfileversion-and-assemblyin.
So there should be a textbox for assembly informational version on assembly info panel .