### PR TITLE
Version Editor should allow other patterns

### DIFF
--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfo.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfo.cs
@@ -39,9 +39,9 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 
 		public string DefaultAlias { get; set; }
 
-		public Version AssemblyVersion { get; set; }
+		public string AssemblyVersion { get; set; }
 
-		public Version AssemblyFileVersion { get; set; }
+		public string AssemblyFileVersion { get; set; }
 
 		public string InformationalVersion { get; set; }
 

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoPanel.xaml
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoPanel.xaml
@@ -88,10 +88,10 @@
 			<TextBox Text="{Binding DefaultAlias, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="6"/>
 			
 			<Label Content="{core:Localize Dialog.ProjectOptions.AssemblyInfo.AssemblyVersion}" Grid.Column="0" Grid.Row="7"/>
-			<projectOptions:VersionEditor Version="{Binding AssemblyVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="7"/>
+			<projectOptions:VersionEditor Version="{Binding AssemblyVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Type="Assembly" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="7"/>
 			
 			<Label Content="{core:Localize Dialog.ProjectOptions.AssemblyInfo.FileVersion}" Grid.Column="0" Grid.Row="8"/>
-			<projectOptions:VersionEditor Version="{Binding AssemblyFileVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="8"/>
+			<projectOptions:VersionEditor Version="{Binding AssemblyFileVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Type="File" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="8"/>
 
 			<Label Content="{core:Localize Dialog.ProjectOptions.AssemblyInfo.InformationalVersion}" Grid.Column="0" Grid.Row="9"/>
 			<TextBox Text="{Binding InformationalVersion, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="9"/>

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoProvider.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoProvider.cs
@@ -122,11 +122,11 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 							break;
 						case AssemblyVersion:
 						case AssemblyVersion + Attribute:
-							assemblyInfo.AssemblyVersion = GetAttributeValueAsVersion(attribute);
+							assemblyInfo.AssemblyVersion = GetAttributeValue<string>(attribute);
 							break;
 						case AssemblyFileVersion:
 						case AssemblyFileVersion + Attribute:
-							assemblyInfo.AssemblyFileVersion = GetAttributeValueAsVersion(attribute);
+							assemblyInfo.AssemblyFileVersion = GetAttributeValue<string>(attribute);
 							break;
 						case AssemblyInformationalVersion:
 						case AssemblyInformationalVersion + Attribute:
@@ -262,23 +262,6 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 					{
 						return guid;
 					}
-				}
-			}
-
-			return null;
-		}
-
-		private Version GetAttributeValueAsVersion(Attribute attribute)
-		{
-			var attributeArguments = attribute.Arguments.OfType<PrimitiveExpression>().ToArray();
-			if (attributeArguments.Length == 1)
-			{
-				var versionString = attributeArguments[0].Value as string;
-				if (!string.IsNullOrEmpty(versionString))
-				{
-					Version version;
-					if (Version.TryParse(versionString, out version))
-						return version;
 				}
 			}
 

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoViewModel.cs
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/AssemblyInfoViewModel.cs
@@ -92,13 +92,13 @@ namespace ICSharpCode.SharpDevelop.Gui.OptionPanels
 			set { assemblyInfo.DefaultAlias = value; OnPropertyChanged(); }
 		}
 
-		public Version AssemblyVersion
+		public string AssemblyVersion
 		{
 			get { return assemblyInfo.AssemblyVersion; }
 			set { assemblyInfo.AssemblyVersion = value; OnPropertyChanged(); }
 		}
 
-		public Version AssemblyFileVersion
+		public string AssemblyFileVersion
 		{
 			get { return assemblyInfo.AssemblyFileVersion; }
 			set { assemblyInfo.AssemblyFileVersion = value; OnPropertyChanged(); }

--- a/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/VersionEditor.xaml
+++ b/src/Main/Base/Project/Src/Gui/Dialogs/OptionPanels/ProjectOptions/AssemblyInfo/VersionEditor.xaml
@@ -11,9 +11,9 @@
             <ColumnDefinition/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
-        <TextBox Name="majorTextBox" Grid.Column="0" PreviewTextInput="OnTextBoxPreviewTextInput" TextChanged="OnTextChanged"/>
-		<TextBox Name="minorTextBox" Grid.Column="1" PreviewTextInput="OnTextBoxPreviewTextInput" TextChanged="OnTextChanged"/>
-		<TextBox Name="buildTextBox" Grid.Column="2" PreviewTextInput="OnTextBoxPreviewTextInput" TextChanged="OnTextChanged"/>
-		<TextBox Name="revisionTextBox" Grid.Column="3" PreviewTextInput="OnTextBoxPreviewTextInput" TextChanged="OnTextChanged"/>
+        <TextBox Name="majorTextBox" Grid.Column="0" TextChanged="OnTextChanged"/>
+        <TextBox Name="minorTextBox" Grid.Column="1" TextChanged="OnTextChanged"/>
+        <TextBox Name="buildTextBox" Grid.Column="2" TextChanged="OnTextChanged"/>
+        <TextBox Name="revisionTextBox" Grid.Column="3" TextChanged="OnTextChanged"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Version Editor should allow other patterns

Do range checking.
AssemblyVersion can have "1.0.*".
AssemblyInformationalVersion can be arbitrary.