### PR TITLE
OutputTextLineParser fix for NUnit tests

### DIFF
--- a/src/AddIns/Analysis/UnitTesting/Model/TestProjectBase.cs
+++ b/src/AddIns/Analysis/UnitTesting/Model/TestProjectBase.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.UnitTesting
 		IProject project;
 		Dictionary<TopLevelTypeName, ITest> topLevelTestClasses = new Dictionary<TopLevelTypeName, ITest>();
 		
-		public TestProjectBase(IProject project)
+		protected TestProjectBase(IProject project)
 		{
 			if (project == null)
 				throw new ArgumentNullException("project");

--- a/src/AddIns/Analysis/UnitTesting/Test/NUnit/NUnitTestResultFailureTestFixture.cs
+++ b/src/AddIns/Analysis/UnitTesting/Test/NUnit/NUnitTestResultFailureTestFixture.cs
@@ -18,7 +18,6 @@
 
 using System;
 using ICSharpCode.NRefactory.TypeSystem;
-using ICSharpCode.SharpDevelop;
 using ICSharpCode.UnitTesting;
 using NUnit.Framework;
 


### PR DESCRIPTION
If we use non-english culture (NET language pack) then some NUnit tests fails because regular expression pattern which used for stack trace parsing was replaced by localized resource string.

This patch provides both cultures (i.e. english and local) to be used for parser, and fixes unit tests in non-english environment.

*I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the #develop open source product (the "Contribution"). My Contribution is licensed under the MIT License.*