### PR TITLE
Wpf designer warning fixes

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/DesignPanel.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/DesignPanel.cs
@@ -35,7 +35,6 @@ using ICSharpCode.WpfDesign.Designer.Controls;
 using ICSharpCode.WpfDesign.UIExtensions;
 using ICSharpCode.WpfDesign.Designer.Xaml;
 using ICSharpCode.WpfDesign.Extensions;
-using System.Linq;
 
 namespace ICSharpCode.WpfDesign.Designer
 {

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/DrawPolyLineExtension.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/DrawPolyLineExtension.cs
@@ -82,7 +82,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		{
 			private ChangeGroup changeGroup;
 			private DesignItem newLine;
-			private Point startPoint;
+			private new Point startPoint;
 
 			public DrawPolylineMouseGesture(DesignItem newLine, IInputElement relativeTo, ChangeGroup changeGroup)
 			{

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/PartialPanelSelectionHandler.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/PartialPanelSelectionHandler.cs
@@ -32,87 +32,91 @@ using ICSharpCode.WpfDesign.Extensions;
 namespace ICSharpCode.WpfDesign.Designer.Extensions
 {
 	public class PartialPanelSelectionHandler : BehaviorExtension, IHandlePointerToolMouseDown
-    {
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.ExtendedItem.AddBehavior(typeof(IHandlePointerToolMouseDown), this);
-        }
+	{
+		protected override void OnInitialized()
+		{
+			base.OnInitialized();
+			this.ExtendedItem.AddBehavior(typeof(IHandlePointerToolMouseDown), this);
+		}
+		
+		#region IHandlePointerToolMouseDown
 
-        public new void HandleSelectionMouseDown(IDesignPanel designPanel, MouseButtonEventArgs e, DesignPanelHitTestResult result)
-        {
-            if (e.ChangedButton == MouseButton.Left && MouseGestureBase.IsOnlyButtonPressed(e, MouseButton.Left))
-            {
-                e.Handled = true;
-                new PartialRangeSelectionGesture(result.ModelHit).Start(designPanel, e);
-            }
-        }
-    }
+		public void HandleSelectionMouseDown(IDesignPanel designPanel, MouseButtonEventArgs e, DesignPanelHitTestResult result)
+		{
+			if (e.ChangedButton == MouseButton.Left && MouseGestureBase.IsOnlyButtonPressed(e, MouseButton.Left))
+			{
+				e.Handled = true;
+				new PartialRangeSelectionGesture(result.ModelHit).Start(designPanel, e);
+			}
+		}
+		
+		#endregion
+	}
 
-    /// <summary>
-    /// 
-    /// </summary>
-    internal class PartialRangeSelectionGesture : RangeSelectionGesture
-    {
-        public PartialRangeSelectionGesture(DesignItem container)
-            : base(container)
-        {
-        }
+	/// <summary>
+	/// 
+	/// </summary>
+	internal class PartialRangeSelectionGesture : RangeSelectionGesture
+	{
+		public PartialRangeSelectionGesture(DesignItem container)
+			: base(container)
+		{
+		}
 
-        protected override ICollection<DesignItem> GetChildDesignItemsInContainer(Geometry geometry)
-        {
-            HashSet<DesignItem> resultItems = new HashSet<DesignItem>();
-            ViewService viewService = container.Services.View;
+		protected override ICollection<DesignItem> GetChildDesignItemsInContainer(Geometry geometry)
+		{
+			HashSet<DesignItem> resultItems = new HashSet<DesignItem>();
+			ViewService viewService = container.Services.View;
 
-            HitTestFilterCallback filterCallback = delegate(DependencyObject potentialHitTestTarget)
-            {
-                FrameworkElement element = potentialHitTestTarget as FrameworkElement;
-                if (element != null)
-                {
-                    // ensure we are able to select elements with width/height=0
-                    if (element.ActualWidth == 0 || element.ActualHeight == 0)
-                    {
-                        DependencyObject tmp = element;
-                        DesignItem model = null;
-                        while (tmp != null)
-                        {
-                            model = viewService.GetModel(tmp);
-                            if (model != null) break;
-                            tmp = VisualTreeHelper.GetParent(tmp);
-                        }
-                        if (model != container)
-                        {
-                            resultItems.Add(model);
-                            return HitTestFilterBehavior.ContinueSkipChildren;
-                        }
-                    }
-                }
-                return HitTestFilterBehavior.Continue;
-            };
+			HitTestFilterCallback filterCallback = delegate(DependencyObject potentialHitTestTarget)
+			{
+				FrameworkElement element = potentialHitTestTarget as FrameworkElement;
+				if (element != null)
+				{
+					// ensure we are able to select elements with width/height=0
+					if (element.ActualWidth == 0 || element.ActualHeight == 0)
+					{
+						DependencyObject tmp = element;
+						DesignItem model = null;
+						while (tmp != null)
+						{
+							model = viewService.GetModel(tmp);
+							if (model != null) break;
+							tmp = VisualTreeHelper.GetParent(tmp);
+						}
+						if (model != container)
+						{
+							resultItems.Add(model);
+							return HitTestFilterBehavior.ContinueSkipChildren;
+						}
+					}
+				}
+				return HitTestFilterBehavior.Continue;
+			};
 
-            HitTestResultCallback resultCallback = delegate(HitTestResult result)
-            {
-                if (((GeometryHitTestResult)result).IntersectionDetail == IntersectionDetail.FullyInside || (Mouse.RightButton== MouseButtonState.Pressed && ((GeometryHitTestResult)result).IntersectionDetail == IntersectionDetail.Intersects))
-                {
-                    // find the model for the visual contained in the selection area
-                    DependencyObject tmp = result.VisualHit;
-                    DesignItem model = null;
-                    while (tmp != null)
-                    {
-                        model = viewService.GetModel(tmp);
-                        if (model != null) break;
-                        tmp = VisualTreeHelper.GetParent(tmp);
-                    }
-                    if (model != container)
-                    {
-                        resultItems.Add(model);
-                    }
-                }
-                return HitTestResultBehavior.Continue;
-            };
+			HitTestResultCallback resultCallback = delegate(HitTestResult result)
+			{
+				if (((GeometryHitTestResult)result).IntersectionDetail == IntersectionDetail.FullyInside || (Mouse.RightButton== MouseButtonState.Pressed && ((GeometryHitTestResult)result).IntersectionDetail == IntersectionDetail.Intersects))
+				{
+					// find the model for the visual contained in the selection area
+					DependencyObject tmp = result.VisualHit;
+					DesignItem model = null;
+					while (tmp != null)
+					{
+						model = viewService.GetModel(tmp);
+						if (model != null) break;
+						tmp = VisualTreeHelper.GetParent(tmp);
+					}
+					if (model != container)
+					{
+						resultItems.Add(model);
+					}
+				}
+				return HitTestResultBehavior.Continue;
+			};
 
-            VisualTreeHelper.HitTest(container.View, filterCallback, resultCallback, new GeometryHitTestParameters(geometry));
-            return resultItems;
-        }
-    }
+			VisualTreeHelper.HitTest(container.View, filterCallback, resultCallback, new GeometryHitTestParameters(geometry));
+			return resultItems;
+		}
+	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/PathHandlerExtension.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/PathHandlerExtension.cs
@@ -160,7 +160,9 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		}
 
 		private readonly Dictionary<int, Bounds> _selectedThumbs = new Dictionary<int, Bounds>();
+#pragma warning disable 0414 // For future use, disable Warning CS0414: The field is assigned but its value is never used
 		private bool _isDragging;
+#pragma warning restore 0414
 		ZoomControl _zoom;
 
 		private List<PathPoint> pathPoints = null;

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/PointTrackerPlacementSupport.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/Extensions/PointTrackerPlacementSupport.cs
@@ -47,7 +47,6 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		public override void Arrange(AdornerPanel panel, UIElement adorner, Size adornedElementSize)
 		{
 			Point p = new Point(0, 0);
-			double distance = 0;
 			if (shape is Line)
 			{
 				var s = shape as Line;

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/OutlineView/OutlineNodeBase.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/OutlineView/OutlineNodeBase.cs
@@ -38,7 +38,7 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 			}
 			catch (Exception)
 			{ }
-			if (hidden != null && (bool)hidden) {
+			if (hidden) {
 				_isDesignTimeVisible = false;
 				((FrameworkElement)DesignItem.Component).Visibility = Visibility.Hidden;
 			}
@@ -50,7 +50,7 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 			}
 			catch (Exception)
 			{ }
-			if (locked != null && (bool)locked) {
+			if (locked) {
 				_isDesignTimeLocked = true;
 			}
 

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/CollectionSupport.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/CollectionSupport.cs
@@ -86,7 +86,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			} else if (collectionInstance is IDictionary) {
 				object val = newElement.GetValueFor(null);
 				object key = newElement is XamlObject ? ((XamlObject)newElement).GetXamlAttribute("Key") : null;
-				if (key == null || key == "")
+				if (key == null || (key as string) == "")
 				{
 					if (val is Style)
 						key = ((Style)val).TargetType;
@@ -134,8 +134,6 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			} catch (MissingMethodException) {
 				return false;
 			}
-			
-			return true;
 		}
 		
 		static readonly Type[] RemoveAtParameters = { typeof(int) };

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/TemplateHelper.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/TemplateHelper.cs
@@ -31,6 +31,7 @@ using System.Xml.XPath;
 
 namespace ICSharpCode.WpfDesign.XamlDom
 {
+#pragma warning disable 1591 // Primary internal use, disable Warning CS1591: Missing XML comment for publicly visible type or member
 	public static class TemplateHelper
 	{
 		public static FrameworkTemplate GetFrameworkTemplate(XmlElement xmlElement, XamlObject parentObject)
@@ -135,4 +136,5 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			return stream;
 		}
 	}
+#pragma warning restore 1591
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/TemplateHelper.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/TemplateHelper.cs
@@ -31,9 +31,17 @@ using System.Xml.XPath;
 
 namespace ICSharpCode.WpfDesign.XamlDom
 {
-#pragma warning disable 1591 // Primary internal use, disable Warning CS1591: Missing XML comment for publicly visible type or member
+	/// <summary>
+	/// Contains template related helper methods.
+	/// </summary>
 	public static class TemplateHelper
 	{
+		/// <summary>
+		/// Gets a <see cref="FrameworkTemplate"/> based on the specified parameters.
+		/// </summary>
+		/// <param name="xmlElement">The xml element to get template xaml from.</param>
+		/// <param name="parentObject">The <see cref="XamlObject"/> to use as source for resources and contextual information.</param>
+		/// <returns>A <see cref="FrameworkTemplate"/> based on the specified parameters.</returns>
 		public static FrameworkTemplate GetFrameworkTemplate(XmlElement xmlElement, XamlObject parentObject)
 		{
 
@@ -136,5 +144,4 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			return stream;
 		}
 	}
-#pragma warning restore 1591
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
@@ -206,6 +206,10 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		}
 
 		private XamlType _systemXamlTypeForProperty = null;
+		
+		/// <summary>
+		/// Gets a <see cref="XamlType"/> representing the <see cref="XamlObject.ElementType"/>.
+		/// </summary>
 		public XamlType SystemXamlTypeForProperty
 		{
 			get

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObjectServiceProvider.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObjectServiceProvider.cs
@@ -125,10 +125,9 @@ namespace ICSharpCode.WpfDesign.XamlDom
 
 		#endregion
 		
-#pragma warning disable 1591 // Implemented interfaces, disable Warning CS1591: Missing XML comment for publicly visible type or member
-
 		#region IUriContext implementation
-		
+
+		/// <inheritdoc/>		
 		public virtual Uri BaseUri {
 			get {
 				return new Uri("pack://application:,,,/");
@@ -153,6 +152,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		//    }
 		//}
 
+		/// <inheritdoc/>
 		public XamlSchemaContext SchemaContext
 		{
 			get
@@ -165,16 +165,19 @@ namespace ICSharpCode.WpfDesign.XamlDom
 
 		#region IAmbientProvider Members
 
+		/// <inheritdoc/>
 		public AmbientPropertyValue GetFirstAmbientValue(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
 		{
 			return GetAllAmbientValues(ceilingTypes, properties).FirstOrDefault();
 		}
 
+		/// <inheritdoc/>
 		public object GetFirstAmbientValue(params XamlType[] types)
 		{
 			return null;
 		}
 
+		/// <inheritdoc/>
 		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
 		{
 			var obj = this.XamlObject.ParentObject;
@@ -196,11 +199,13 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			}
 		}
 
+		/// <inheritdoc/>
 		public IEnumerable<object> GetAllAmbientValues(params XamlType[] types)
 		{
 			return new List<object>();
 		}
 
+		/// <inheritdoc/>
 		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types, params XamlMember[] properties)
 		{
 			return new List<AmbientPropertyValue>();
@@ -210,6 +215,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 
 		#region IXamlNameResolver
 
+		/// <inheritdoc/>
 		public object Resolve(string name)
 		{
 			INameScope ns = null;
@@ -230,6 +236,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			return null;
 		}
 
+		/// <inheritdoc/>
 		public object Resolve(string name, out bool isFullyInitialized)
 		{
 			var ret = Resolve(name);
@@ -237,32 +244,35 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			return ret;
 		}
 
+		/// <inheritdoc/>
 		public object GetFixupToken(IEnumerable<string> names)
 		{
 			return null;
 		}
 
+		/// <inheritdoc/>
 		public object GetFixupToken(IEnumerable<string> names, bool canAssignDirectly)
 		{
 			return null;
 		}
 
+		/// <inheritdoc/>
 		public IEnumerable<KeyValuePair<string, object>> GetAllNamesAndValuesInScope()
 		{
 			return null;
 		}
 
+		/// <inheritdoc/>
 		public bool IsFixupTokenAvailable
 		{
 			get { return false; }
 		}
 
 #pragma warning disable 0067 // Required by interface implementation, disable Warning CS0067: The event is never used
+		/// <inheritdoc/>
 		public event EventHandler OnNameScopeInitializationComplete;
 #pragma warning restore 0067
 
 		#endregion
-		
-#pragma warning restore 1591
 	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObjectServiceProvider.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObjectServiceProvider.cs
@@ -124,6 +124,8 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		}
 
 		#endregion
+		
+#pragma warning disable 1591 // Implemented interfaces, disable Warning CS1591: Missing XML comment for publicly visible type or member
 
 		#region IUriContext implementation
 		
@@ -255,8 +257,12 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			get { return false; }
 		}
 
+#pragma warning disable 0067 // Required by interface implementation, disable Warning CS0067: The event is never used
 		public event EventHandler OnNameScopeInitializationComplete;
+#pragma warning restore 0067
 
 		#endregion
+		
+#pragma warning restore 1591
 	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlParser.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlParser.cs
@@ -607,7 +607,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 				{
 					propertyInfo = FindProperty(elementInstance, propertyType, propertyName);
 				}
-				catch (Exception ex)
+				catch (Exception)
 				{ }
 				if (propertyInfo != null)
 					return propertyInfo;

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlProperty.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlProperty.cs
@@ -250,6 +250,10 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		}
 
 		private XamlMember _systemXamlMemberForProperty = null;
+		
+		/// <summary>
+		/// Gets a <see cref="XamlMember"/> representing the property. 
+		/// </summary>
 		public XamlMember SystemXamlMemberForProperty
 		{
 			get
@@ -261,6 +265,10 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		}
 
 		private XamlType _systemXamlTypeForProperty = null;
+		
+		/// <summary>
+		/// Gets a <see cref="XamlType"/> representing the type the property is declared on. 
+		/// </summary>
 		public XamlType SystemXamlTypeForProperty
 		{
 			get

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlTypeFinder.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlTypeFinder.cs
@@ -304,6 +304,9 @@ namespace ICSharpCode.WpfDesign.XamlDom
 			return WpfTypeFinder.Instance.Clone();
 		}
 		
+		/// <summary>
+		/// Converts the specified <see cref="Uri"/> to local.
+		/// </summary>
 		public virtual Uri ConvertUriToLocalUri(Uri uri)
 		{
 			return uri;

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DesignItem.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DesignItem.cs
@@ -199,6 +199,9 @@ namespace ICSharpCode.WpfDesign
 			}
 		}
 
+		/// <summary>
+		/// Reapplies all extensions.
+		/// </summary>
 		public void ReapplyAllExtensions()
 		{
 			var manager = this.Services.GetService<Extensions.ExtensionManager>();
@@ -293,6 +296,9 @@ namespace ICSharpCode.WpfDesign
 		/// </summary>
 		public abstract DesignItem Clone();
 		
+		/// <summary>
+		/// Gets a <see cref="Transform"/> that represents all transforms applied to the item's view.
+		/// </summary>
 		public Transform GetCompleteAppliedTransformationToView()
 		{
 			var retVal = new TransformGroup();

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DrawItemExtension.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DrawItemExtension.cs
@@ -29,7 +29,20 @@ namespace ICSharpCode.WpfDesign
 	/// </summary>
 	public interface IDrawItemExtension
 	{
+		/// <summary>
+		/// Returns if the specified type can be drawn.
+		/// </summary>
+		/// <param name="createItemType">The type to check.</param>
+		/// <returns>True if the specified type can be drawn, otherwise false.</returns>
 		bool CanItemBeDrawn(Type createItemType);
+		
+		/// <summary>
+		/// Starts to draw.
+		/// </summary>
+		/// <param name="clickedOn">The item.</param>
+		/// <param name="createItemType">The item type.</param>
+		/// <param name="panel">The design panel to draw on.</param>
+		/// <param name="e">The <see cref="MouseEventArgs"/> argument that initiated the draw operation.</param>
 		void StartDrawItem(DesignItem clickedOn, Type createItemType, IDesignPanel panel, MouseEventArgs e);
 	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DummyValueInsteadOfNullTypeDescriptionProvider.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DummyValueInsteadOfNullTypeDescriptionProvider.cs
@@ -46,12 +46,11 @@ namespace ICSharpCode.WpfDesign
 			this._dummyValue = dummyValue;
 		}
 		
-#pragma warning disable 1591 // Override, disable Warning CS1591: Missing XML comment for publicly visible type or member
+		/// <inheritdoc/>
 		public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
 		{
 			return new ShadowTypeDescriptor(this, base.GetTypeDescriptor(objectType, instance));
 		}
-#pragma warning restore 1591
 		
 		sealed class ShadowTypeDescriptor : CustomTypeDescriptor
 		{

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DummyValueInsteadOfNullTypeDescriptionProvider.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/DummyValueInsteadOfNullTypeDescriptionProvider.cs
@@ -35,6 +35,9 @@ namespace ICSharpCode.WpfDesign
 		readonly string _propertyName;
 		readonly object _dummyValue;
 		
+		/// <summary>
+		/// Initializes a new instance of <see cref="DummyValueInsteadOfNullTypeDescriptionProvider"/>.
+		/// </summary>
 		public DummyValueInsteadOfNullTypeDescriptionProvider(TypeDescriptionProvider existingProvider,
 		                                                      string propertyName, object dummyValue)
 			: base(existingProvider)
@@ -43,10 +46,12 @@ namespace ICSharpCode.WpfDesign
 			this._dummyValue = dummyValue;
 		}
 		
+#pragma warning disable 1591 // Override, disable Warning CS1591: Missing XML comment for publicly visible type or member
 		public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
 		{
 			return new ShadowTypeDescriptor(this, base.GetTypeDescriptor(objectType, instance));
 		}
+#pragma warning restore 1591
 		
 		sealed class ShadowTypeDescriptor : CustomTypeDescriptor
 		{

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/Extension.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/Extension.cs
@@ -33,16 +33,29 @@ namespace ICSharpCode.WpfDesign.Extensions
 	/// </remarks>
 	public abstract class Extension
 	{
+		/// <summary>
+		/// Gets the value of the <see cref="DisabledExtensionsProperty"/> attached property for an object.
+		/// </summary>
+		/// <param name="obj">The object from which the property value is read.</param>
+		/// <returns>The object's <see cref="DisabledExtensionsProperty"/> property value.</returns>
 		public static string GetDisabledExtensions(DependencyObject obj)
 		{
 			return (string)obj.GetValue(DisabledExtensionsProperty);
 		}
 
+		/// <summary>
+		/// Sets the value of the <see cref="DisabledExtensionsProperty"/> attached property for an object. 
+		/// </summary>
+		/// <param name="obj">The object to which the attached property is written.</param>
+		/// <param name="value">The value to set.</param>
 		public static void SetDisabledExtensions(DependencyObject obj, string value)
 		{
 			obj.SetValue(DisabledExtensionsProperty, value);
 		}
 
+		/// <summary>
+		/// Gets or sets a semicolon-separated list with extension names that is disabled for a component's view.
+		/// </summary>
 		public static readonly DependencyProperty DisabledExtensionsProperty =
 			DependencyProperty.RegisterAttached("DisabledExtensions", typeof(string), typeof(Extension), new PropertyMetadata(null));
 

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/ExtensionAttribute.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/ExtensionAttribute.cs
@@ -26,7 +26,9 @@ namespace ICSharpCode.WpfDesign.Extensions
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
 	public sealed class ExtensionAttribute : Attribute
 	{
-	    //The Order in wich the Extensions are used
-        public int Order { get; set; }
+		/// <summary>
+		/// Gets or sets the Order in wich the extensions are used.
+		/// </summary>
+		public int Order { get; set; }
 	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/ExtensionServer.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/ExtensionServer.cs
@@ -74,8 +74,8 @@ namespace ICSharpCode.WpfDesign.Extensions
 		/// </summary>
 		public abstract bool ShouldApplyExtensions(DesignItem extendedItem);
 		
-		// <summary>
-		/// Set if the Extension Server should be reaplied (For multiple Selection extension Server for Example!)
+		/// <summary>
+		/// Returns if the Extension Server should be reapplied (for multiple selection extension server for example).
 		/// </summary>
 		public virtual bool ShouldBeReApplied() 
 		{

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/SelectionExtensionServer.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/SelectionExtensionServer.cs
@@ -121,12 +121,11 @@ namespace ICSharpCode.WpfDesign.Extensions
 			ReapplyExtensions(this.Services.Selection.SelectedItems);
 		}
 		
-#pragma warning disable 1591 // Override, disable Warning CS1591: Missing XML comment for publicly visible type or member
+		/// <inheritdoc/>
 		public override bool ShouldBeReApplied()
 		{
 			return true;
 		}
-#pragma warning restore 1591
 		
 		/// <summary>
 		/// Gets if the item is in the secondary selection.

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/SelectionExtensionServer.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/Extensions/SelectionExtensionServer.cs
@@ -121,10 +121,12 @@ namespace ICSharpCode.WpfDesign.Extensions
 			ReapplyExtensions(this.Services.Selection.SelectedItems);
 		}
 		
+#pragma warning disable 1591 // Override, disable Warning CS1591: Missing XML comment for publicly visible type or member
 		public override bool ShouldBeReApplied()
 		{
 			return true;
 		}
+#pragma warning restore 1591
 		
 		/// <summary>
 		/// Gets if the item is in the secondary selection.

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/UIExtensions/UIHelpers.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/UIExtensions/UIHelpers.cs
@@ -25,8 +25,13 @@ using System.Windows.Media;
 
 namespace ICSharpCode.WpfDesign.UIExtensions
 {
+	/// <summary>
+	/// Contains helper methods for UI. 
+	/// </summary>
 	public static class UIHelpers
 	{
+#pragma warning disable 1591 // Primary internal use, disable Warning CS1591: Missing XML comment for publicly visible type or member
+
 		public static DependencyObject GetParentObject(this DependencyObject child, bool searchCompleteVisualTree)
 		{
 			if (child == null) return null;
@@ -119,5 +124,7 @@ namespace ICSharpCode.WpfDesign.UIExtensions
 			}
 			return foundChild;
 		}
+		
+#pragma warning restore 1591
 	}
 }

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/UIExtensions/UIHelpers.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign/Project/UIExtensions/UIHelpers.cs
@@ -30,8 +30,12 @@ namespace ICSharpCode.WpfDesign.UIExtensions
 	/// </summary>
 	public static class UIHelpers
 	{
-#pragma warning disable 1591 // Primary internal use, disable Warning CS1591: Missing XML comment for publicly visible type or member
-
+		/// <summary>
+		/// Gets the parent. Which tree the parent is retrieved from depends on the parameters.
+		/// </summary>
+		/// <param name="child">The child to get parent for.</param>
+		/// <param name="searchCompleteVisualTree">If true the parent in the visual tree is returned, if false the parent may be retrieved from another tree depending on the child type.</param>
+		/// <returns>The parent element, and depending on the parameters its retrieved from either visual tree, logical tree or a tree not strictly speaking either the logical tree or the visual tree.</returns>
 		public static DependencyObject GetParentObject(this DependencyObject child, bool searchCompleteVisualTree)
 		{
 			if (child == null) return null;
@@ -58,6 +62,15 @@ namespace ICSharpCode.WpfDesign.UIExtensions
 			return VisualTreeHelper.GetParent(child);
 		}
 
+		/// <summary>
+		/// Gets first parent element of the specified type. Which tree the parent is retrieved from depends on the parameters.
+		/// </summary>
+		/// <param name="child">The child to get parent for.</param>
+		/// <param name="searchCompleteVisualTree">If true the parent in the visual tree is returned, if false the parent may be retrieved from another tree depending on the child type.</param>
+		/// <returns>
+		/// The first parent element of the specified type, and depending on the parameters its retrieved from either visual tree, logical tree or a tree not strictly speaking either the logical tree or the visual tree.
+		/// null is returned if no parent of the specified type is found.
+		/// </returns>
 		public static T TryFindParent<T>(this DependencyObject child, bool searchCompleteVisualTree = false) where T : DependencyObject
 		{
 			DependencyObject parentObject = GetParentObject(child, searchCompleteVisualTree);
@@ -73,6 +86,11 @@ namespace ICSharpCode.WpfDesign.UIExtensions
 			return TryFindParent<T>(parentObject);
 		}
 
+		/// <summary>
+		/// Returns the first child of the specified type found in the visual tree.
+		/// </summary>
+		/// <param name="parent">The parent element where the search is started.</param>
+		/// <returns>The first child of the specified type found in the visual tree, or null if no parent of the specified type is found.</returns>
 		public static T TryFindChild<T>(this DependencyObject parent) where T : DependencyObject
 		{
 			for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
@@ -92,6 +110,12 @@ namespace ICSharpCode.WpfDesign.UIExtensions
 			return null;
 		}
 
+		/// <summary>
+		/// Returns the first child of the specified type and with the specified name found in the visual tree.
+		/// </summary>
+		/// <param name="parent">The parent element where the search is started.</param>
+		/// <param name="childName">The name of the child element to find, or an empty string or null to only look at the type.</param>
+		/// <returns>The first child that matches the specified type and child name, or null if no match is found.</returns>
 		public static T TryFindChild<T>(this DependencyObject parent, string childName) where T : DependencyObject
 		{
 			if (parent == null) return null;
@@ -124,7 +148,5 @@ namespace ICSharpCode.WpfDesign.UIExtensions
 			}
 			return foundChild;
 		}
-		
-#pragma warning restore 1591
 	}
 }


### PR DESCRIPTION
With the experience that a big number of warnings often results in important warnings being missed I fixed some of the annoying warnings that have been piling up for a while, and did indeed find a comparison bug.

If its not too much work I would appreciate if you started declining pull requests that adds new warnings, otherwise this problem will be here again sooner or later.