### PR TITLE
Tab headers should not expose technology names or words.

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/PropertyGrid/Editors/BrushEditor/BrushEditorView.xaml
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/PropertyGrid/Editors/BrushEditor/BrushEditorView.xaml
@@ -72,12 +72,12 @@
 		<TabItem Header="Radial">
 			<BrushEditor:GradientBrushEditor />
 		</TabItem>
-		<TabItem Header="Brush List">
+		<TabItem Header="System brushes">
 			<ListBox MaxHeight="320" ItemsSource="{Binding AvailableBrushes}"
 			         SelectedValue="{Binding Brush.Color}"
 			         SelectedValuePath="Brush.Color" />
 		</TabItem>
-		<TabItem Header="Wpf Brush List">
+		<TabItem Header="Brushes">
 			<ListBox MaxHeight="320" ItemsSource="{Binding AvailableWpfBrushes}"
 			         SelectedValue="{Binding Brush.Color}"
 			         SelectedValuePath="Brush.Color" />

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/PropertyGrid/Editors/BrushEditor/SolidBrushEditor.xaml
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.Designer/Project/PropertyGrid/Editors/BrushEditor/SolidBrushEditor.xaml
@@ -8,12 +8,12 @@
 		<TabItem Header="Color Picker">
 			<widgets:ColorPicker Color="{Binding Color, ElementName=this}" />
 		</TabItem>
-		<TabItem Header="Color List">
+		<TabItem Header="System colors">
 			<ListBox ItemsSource="{Binding AvailableColors}"
 			         SelectedValue="{Binding Color, ElementName=this}"
 			         SelectedValuePath="Brush.Color" />
 		</TabItem>
-		<TabItem Header="Wpf Color List">
+		<TabItem Header="Colors">
 			<ListBox ItemsSource="{Binding AvailableWpfBrushes}"
 			         SelectedValue="{Binding Color, ElementName=this}"
 			         SelectedValuePath="Brush.Color" />


### PR DESCRIPTION
I hope you agree :)

And even if used in SD with WPF projects, it should be well-implied by the context.