### PR TITLE
Fixed bug with unresolved resources in Binding inside MultiBinding

### DIFF
--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlObject.cs
@@ -283,8 +283,17 @@ namespace ICSharpCode.WpfDesign.XamlDom
 		
 		void UpdateChildMarkupExtensions(XamlObject obj)
 		{
-			foreach (XamlObject propXamlObject in obj.Properties.Where((prop) => prop.IsSet).Select((prop) => prop.PropertyValue).OfType<XamlObject>()) {
-				UpdateChildMarkupExtensions(propXamlObject);
+			foreach (var prop in obj.Properties) {
+				if (prop.IsSet) {
+					var propXamlObject = prop.PropertyValue as XamlObject;
+					if (propXamlObject != null) {
+						UpdateChildMarkupExtensions(propXamlObject);
+					}
+				} else if (prop.IsCollection) {
+					foreach (var propXamlObject in prop.CollectionElements.OfType<XamlObject>()) {
+						UpdateChildMarkupExtensions(propXamlObject);
+					}
+				}
 			}
 
 			if (obj.IsMarkupExtension && obj.ParentProperty != null) {

--- a/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlProperty.cs
+++ b/src/AddIns/DisplayBindings/WpfDesign/WpfDesign.XamlDom/Project/XamlProperty.cs
@@ -266,6 +266,15 @@ namespace ICSharpCode.WpfDesign.XamlDom
 				catch (Exception ex) {
 					Debug.WriteLine("UpdateValueOnInstance() failed - Exception:" + ex.Message);
 				}
+			} else if (IsCollection) {
+				var list = ValueOnInstance as System.Collections.IList;
+				if (list != null) {
+					list.Clear();
+					foreach (var item in CollectionElements) {
+						var newValue = item.GetValueFor(propertyInfo);
+						list.Add(newValue);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
If a Binding inside a MultiBinding is referencing a resource not available until the MultiBinding is added to the tree, the resource was not resolved.