### PR TITLE
Debug: Start external program with arguments

### DIFF
--- a/src/AddIns/Debugger/Debugger.Core/Interop/CorDebugExtensionMethods.generated.cs
+++ b/src/AddIns/Debugger/Debugger.Core/Interop/CorDebugExtensionMethods.generated.cs
@@ -170,7 +170,7 @@ namespace Debugger.Interop.CorDebug
 		uint lpProcessInformation, CorDebugCreateProcessFlags debuggingFlags)
 		{
 			ICorDebugProcess ppProcess;
-			instance.__CreateProcess(lpApplicationName, lpCommandLine, ref lpProcessAttributes, ref lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation,
+			instance.__CreateProcess(lpApplicationName, lpApplicationName + lpCommandLine, ref lpProcessAttributes, ref lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation,
 			debuggingFlags, out ppProcess);
 			ProcessOutParameter(lpProcessAttributes);
 			ProcessOutParameter(lpThreadAttributes);


### PR DESCRIPTION
Hello :)

Trying to debug a program with "start external program" with "Command line arguments" the program no received the arguments.

To start one procress with arguments using ICorDebug the argument parameter needs the application name.

See more at: http://blogs.msdn.com/b/jmstall/archive/2006/07/09/createprocess-conventions.aspx
