### PR TITLE
Using Dispatcher when accessing the ItemsSource of the start page

### DIFF
--- a/src/AddIns/Misc/StartPage/Project/Src/RecentProjectsControl.xaml.cs
+++ b/src/AddIns/Misc/StartPage/Project/Src/RecentProjectsControl.xaml.cs
@@ -79,10 +79,15 @@ namespace ICSharpCode.StartPage
 						}
 					}
 				});
-			if (items.Count > 0) {
-				lastProjectsListView.ItemsSource = items;
-				lastProjectsListView.Visibility = Visibility.Visible;
-			}
+
+      await Dispatcher.InvokeAsync(delegate
+       {
+         if (items.Count > 0)
+         {
+           lastProjectsListView.ItemsSource = items;
+           lastProjectsListView.Visibility = Visibility.Visible;
+         }
+       });
 		}
 		
 		class RecentOpenItem : INotifyPropertyChanged


### PR DESCRIPTION
When using SDA the initialization of recent projects on start page, because after await another thread tried to access ItemSource
